### PR TITLE
Mobile finetuning

### DIFF
--- a/public/tradingview.css
+++ b/public/tradingview.css
@@ -332,6 +332,9 @@ button[class^='button-'][class*='secondary-']:hover {
 
 [class^='noWrapWrapper-'] * {
   pointer-events: none !important;
+  border: none !important;
+  background: transparent !important;
+  outline: none !important;
 }
 
 html.theme-dark ::selection {

--- a/public/tradingview.css
+++ b/public/tradingview.css
@@ -330,6 +330,10 @@ button[class^='button-'][class*='secondary-']:hover {
   background-image: linear-gradient(0deg, var(--tv-background), transparent) !important;
 }
 
+[class^='noWrapWrapper-'] * {
+  pointer-events: none !important;
+}
+
 html.theme-dark ::selection {
   background: var(--tv-background) !important;
   color: var(--tv-menu-text-hover) !important;

--- a/src/components/Wallet/WalletConnectButton.tsx
+++ b/src/components/Wallet/WalletConnectButton.tsx
@@ -23,7 +23,7 @@ export default function WalletConnectButton(props: Props) {
 
   const handleClick = useCallback(() => {
     const component = hasAgreedToTerms ? <WalletSelect /> : <TermsOfService />
-    useStore.setState({ focusComponent: { component } })
+    useStore.setState({ focusComponent: { component }, mobileNavExpanded: false })
   }, [hasAgreedToTerms])
 
   return (

--- a/src/components/common/LeverageSlider/index.tsx
+++ b/src/components/common/LeverageSlider/index.tsx
@@ -66,8 +66,8 @@ function LeverageSlider(props: Props) {
             'relative w-full appearance-none bg-transparent hover:cursor-pointer',
             '[&::-webkit-slider-runnable-track]:bg-white [&::-webkit-slider-runnable-track]:bg-opacity-20 [&::-webkit-slider-runnable-track]:h-[9px] [&::-webkit-slider-runnable-track]:rounded-lg',
             '[&::-moz-range-track]:bg-white [&::-moz-range-track]:bg-opacity-20 [&::-moz-range-track]:h-1 [&::-moz-range-track]:pb-[5px] [&::-moz-range-track]:rounded-lg',
-            '[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:-mt-1 [&::-webkit-slider-thumb]:w-[33px] [&::-webkit-slider-thumb]:h-4',
-            '[&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:opacity-0 [&::-moz-range-thumb]:w-[33px] [&::-moz-range-thumb]:h-4',
+            '[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-transparent [&::-webkit-slider-thumb]:-mt-1 [&::-webkit-slider-thumb]:w-[33px] [&::-webkit-slider-thumb]:h-4',
+            '[&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:bg-transparent [&::-moz-range-thumb]:opacity-0 [&::-moz-range-thumb]:w-[33px] [&::-moz-range-thumb]:h-4',
           )}
           type='range'
           value={value.toFixed(2)}

--- a/src/components/header/ChainSelect.tsx
+++ b/src/components/header/ChainSelect.tsx
@@ -85,6 +85,7 @@ export default function ChainSelect(props: Props) {
       setCurrentChainId(chainConfig.id)
       mutate(() => true)
       useStore.setState({
+        mobileNavExpanded: false,
         chainConfig,
         isV1: false,
         client: undefined,
@@ -114,6 +115,7 @@ export default function ChainSelect(props: Props) {
                   setCurrentChainId(chainConfig.id)
                   useStore.setState({
                     chainConfig,
+                    mobileNavExpanded: false,
                   })
                 }
                 window.open(outpost?.url, outpost?.target)

--- a/src/components/header/navigation/mobile/MobileNavigation.tsx
+++ b/src/components/header/navigation/mobile/MobileNavigation.tsx
@@ -1,6 +1,6 @@
 import { useShuttle } from '@delphi-labs/shuttle-react'
 import classNames from 'classnames'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
 import AccountMenu from 'components/account/AccountMenu'
@@ -38,6 +38,18 @@ export default function MobileNavigation(props: Props) {
 
   const menu = useMemo(() => menuTree(walletId, chainConfig), [walletId, chainConfig, menuTree])
 
+  useEffect(() => {
+    if (mobileNavExpanded) {
+      document.body.classList.add('h-screen-full', 'overflow-hidden')
+    } else {
+      document.body.classList.remove('h-screen-full', 'overflow-hidden')
+    }
+
+    return () => {
+      document.body.classList.remove('h-screen-full', 'overflow-hidden')
+    }
+  }, [mobileNavExpanded])
+
   const selectPage = useCallback(
     (page: Page) => {
       useStore.setState({ mobileNavExpanded: false })
@@ -53,7 +65,7 @@ export default function MobileNavigation(props: Props) {
   return (
     <nav
       className={classNames(
-        'fixed md:hidden max-w-screen-full w-screen-full top-18 p-2 pt-4 pb-8 transition-all overflow-y-scroll h-[calc(100dvh-72px)] z-20 items-start',
+        'fixed md:hidden max-w-screen-full w-screen-full top-18 p-2 pt-4 pb-20 transition-all overflow-y-scroll h-[calc(100dvh-72px)] z-20 items-start',
         mobileNavExpanded ? 'right-0 opacity-100' : '-right-full opacity-0',
       )}
     >

--- a/src/components/header/navigation/mobile/MobileNavigation.tsx
+++ b/src/components/header/navigation/mobile/MobileNavigation.tsx
@@ -52,6 +52,8 @@ export default function MobileNavigation(props: Props) {
 
   const selectPage = useCallback(
     (page: Page) => {
+      window.scrollTo(0, 0)
+      if (typeof window !== 'undefined') setTimeout(() => window.scrollTo(0, 0), 200)
       useStore.setState({ mobileNavExpanded: false })
       if (page.includes('http')) {
         window.open(page, '_blank')

--- a/src/components/trade/TradeModule/AssetSelector/AssetOverlay/index.tsx
+++ b/src/components/trade/TradeModule/AssetSelector/AssetOverlay/index.tsx
@@ -11,6 +11,7 @@ import PairsList from 'components/trade/TradeModule/AssetSelector/PairsList'
 import useCurrentAccount from 'hooks/accounts/useCurrentAccount'
 import useAllAssets from 'hooks/assets/useAllAssets'
 import useFilteredAssets from 'hooks/useFilteredAssets'
+import { isMobile } from 'react-device-detect'
 
 interface Props {
   state: OverlayState
@@ -100,7 +101,7 @@ export default function AssetOverlay(props: Props) {
 
   return (
     <Overlay
-      className='left-0 w-full overflow-y-scroll  scrollbar-hide top-18 md:inset-0'
+      className='left-0 w-full overflow-y-scroll h-screen-full scrollbar-hide top-18 md:inset-0'
       show={props.state !== 'closed'}
       setShow={handleClose}
     >
@@ -122,7 +123,7 @@ export default function AssetOverlay(props: Props) {
           value={searchString}
           onChange={onChangeSearch}
           placeholder='Search for e.g. "ETH" or "Ethereum"'
-          autoFocus
+          autoFocus={!isMobile}
         />
       </div>
       <Divider />

--- a/src/components/trade/TradeModule/AssetSelector/AssetOverlay/index.tsx
+++ b/src/components/trade/TradeModule/AssetSelector/AssetOverlay/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
+import { isMobile } from 'react-device-detect'
 
 import EscButton from 'components/common/Button/EscButton'
 import Divider from 'components/common/Divider'
@@ -11,7 +12,6 @@ import PairsList from 'components/trade/TradeModule/AssetSelector/PairsList'
 import useCurrentAccount from 'hooks/accounts/useCurrentAccount'
 import useAllAssets from 'hooks/assets/useAllAssets'
 import useFilteredAssets from 'hooks/useFilteredAssets'
-import { isMobile } from 'react-device-detect'
 
 interface Props {
   state: OverlayState

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -75,7 +75,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             'mt-[73px]',
             'flex',
             'min-h-screen-full w-full relative',
-            'gap-4 p-2 pb-10',
+            'gap-4 p-2 pb-20',
             'md:gap-6 md:px-4 md:py-6 ',
             !focusComponent &&
               address &&


### PR DESCRIPTION
- interacting with the navigation elements of the `ChainSelect` now closes the `MobileNavigation`
- starting the wallet connection now cloeses the `MobileNavigation`
- the content behind the `MobileNavigation` is not scrollable anymore
- after selecting a navigation point inside `MobileNavigation` the page is scrolled to the top position
- the chart interactions have been updated. Selecting a custom Symbol or Interval is now permitted. Changing preset intervals is still enabled
- slider thumbs don't have a solid white background anymore