### PR TITLE
Mp 2386 add manage button to portfolio account detail view

### DIFF
--- a/src/components/Modals/Account/AccountDeleteModal.tsx
+++ b/src/components/Modals/Account/AccountDeleteModal.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useMemo } from 'react'
 import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { useSWRConfig } from 'swr'
 
 import AccountDeleteAlertDialog from 'components/Modals/Account/AccountDeleteAlertDialog'
 import { ArrowRight, ExclamationMarkCircled } from 'components/common/Icons'
 import Text from 'components/common/Text'
 import AssetBalanceRow from 'components/common/assets/AssetBalanceRow'
 import useAllAssets from 'hooks/assets/useAllAssets'
+import useChainConfig from 'hooks/chain/useChainConfig'
 import useStore from 'store'
 import { BNCoin } from 'types/classes/BNCoin'
 import { byDenom } from 'utils/array'
@@ -26,7 +28,10 @@ export default function AccountDeleteController() {
 
 function AccountDeleteModal(props: Props) {
   const modal = props.modal
+  const chainConfig = useChainConfig()
   const deleteAccount = useStore((s) => s.deleteAccount)
+  const { mutate } = useSWRConfig()
+  const { address: urlAddress } = useParams()
   const navigate = useNavigate()
   const { pathname } = useLocation()
   const { address } = useParams()
@@ -37,10 +42,18 @@ function AccountDeleteModal(props: Props) {
     useStore.setState({ accountDeleteModal: null })
   }, [])
 
-  const deleteAccountHandler = useCallback(() => {
+  const deleteAccountHandler = useCallback(async () => {
     const options = { accountId: modal.id, lends: modal.lends }
-    deleteAccount(options)
-    navigate(getRoute(getPage(pathname), searchParams, address))
+    const path = getPage(pathname)
+    const isDeleted = await deleteAccount(options)
+    if (isDeleted) {
+      mutate(`chains/${chainConfig.id}/wallets/${urlAddress}/account-ids`)
+      if (path.includes('portfolio')) {
+        navigate(getRoute('portfolio', searchParams, urlAddress))
+      } else {
+        navigate(getRoute(path, searchParams, address))
+      }
+    }
     closeDeleteAccountModal()
   }, [
     modal.id,
@@ -50,6 +63,9 @@ function AccountDeleteModal(props: Props) {
     pathname,
     searchParams,
     address,
+    urlAddress,
+    chainConfig.id,
+    mutate,
     closeDeleteAccountModal,
   ])
 

--- a/src/components/Modals/Account/AccountDeleteModal.tsx
+++ b/src/components/Modals/Account/AccountDeleteModal.tsx
@@ -49,6 +49,7 @@ function AccountDeleteModal(props: Props) {
     if (isDeleted) {
       mutate(`chains/${chainConfig.id}/wallets/${urlAddress}/account-ids`)
       if (path.includes('portfolio')) {
+        // If the current page is the portfolio accounts detail page. Reroute the user to the portfolio overview page.
         navigate(getRoute('portfolio', searchParams, urlAddress))
       } else {
         navigate(getRoute(path, searchParams, address))

--- a/src/components/account/AccountBalancesTable/index.tsx
+++ b/src/components/account/AccountBalancesTable/index.tsx
@@ -9,7 +9,6 @@ import Card from 'components/common/Card'
 import Table from 'components/common/Table'
 import Text from 'components/common/Text'
 import ConditionalWrapper from 'hocs/ConditionalWrapper'
-import useAccountIds from 'hooks/accounts/useAccountIds'
 import useCurrentAccount from 'hooks/accounts/useCurrentAccount'
 import useStore from 'store'
 import { getPage, getRoute } from 'utils/route'
@@ -21,6 +20,7 @@ interface Props {
   hideCard?: boolean
   tableBodyClassName?: string
   showLiquidationPrice?: boolean
+  isUsersAccount?: boolean
 }
 
 export default function AccountBalancesTable(props: Props) {
@@ -32,6 +32,7 @@ export default function AccountBalancesTable(props: Props) {
     tableBodyClassName,
     hideCard,
     showLiquidationPrice,
+    isUsersAccount,
   } = props
   const currentAccount = useCurrentAccount()
   const navigate = useNavigate()
@@ -47,8 +48,6 @@ export default function AccountBalancesTable(props: Props) {
     isHls,
   })
   const columns = useAccountBalancesColumns(account, showLiquidationPrice)
-  const { data: accountIds } = useAccountIds(address)
-  const isUsersAccount = accountIds?.includes(account.id)
 
   if (accountBalanceData.length === 0) {
     return (

--- a/src/components/account/AccountSummary/index.tsx
+++ b/src/components/account/AccountSummary/index.tsx
@@ -12,10 +12,10 @@ import { DEFAULT_SETTINGS } from 'constants/defaultSettings'
 import { LocalStorageKeys } from 'constants/localStorageKeys'
 import { BN_ZERO } from 'constants/math'
 import useAllAssets from 'hooks/assets/useAllAssets'
+import useHealthComputer from 'hooks/health-computer/useHealthComputer'
 import useHLSStakingAssets from 'hooks/hls/useHLSStakingAssets'
 import useLocalStorage from 'hooks/localStorage/useLocalStorage'
 import usePrices from 'hooks/prices/usePrices'
-import useHealthComputer from 'hooks/health-computer/useHealthComputer'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
 import useStore from 'store'
 import { calculateAccountApr, calculateAccountLeverage } from 'utils/accounts'
@@ -117,7 +117,6 @@ export default function AccountSummary(props: Props) {
               borrowingData={borrowAssetsData}
               lendingData={lendingAssetsData}
               hideCard
-              isHls={isHls}
             />
           ) : null,
         isOpen: accountSummaryTabs[1],

--- a/src/components/portfolio/Account/Balances.tsx
+++ b/src/components/portfolio/Account/Balances.tsx
@@ -6,15 +6,14 @@ import Card from 'components/common/Card'
 import TableSkeleton from 'components/common/Table/TableSkeleton'
 import Text from 'components/common/Text'
 import useLendingMarketAssetsTableData from 'components/earn/lend/Table/useLendingMarketAssetsTableData'
-import useAccount from 'hooks/accounts/useAccount'
 
 interface Props {
-  accountId: string
+  isUsersAccount?: boolean
+  account: Account
 }
 
 function Content(props: Props) {
-  const { data: account } = useAccount(props.accountId, true)
-
+  const { isUsersAccount, account } = props
   const data = useBorrowMarketAssetsTableData()
   const borrowAssets = useMemo(() => data?.allAssets || [], [data])
   const { allAssets: lendingAssets } = useLendingMarketAssetsTableData()
@@ -29,6 +28,7 @@ function Content(props: Props) {
         account={account}
         borrowingData={borrowAssets}
         lendingData={lendingAssets}
+        isUsersAccount={isUsersAccount}
         showLiquidationPrice
         hideCard
       />

--- a/src/components/portfolio/Account/ManageAccount.tsx
+++ b/src/components/portfolio/Account/ManageAccount.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useMemo } from 'react'
+
+import AccountFundFullPage from 'components/account/AccountFund/AccountFundFullPage'
+import Button from 'components/common/Button'
+import { ArrowDownLine, ArrowUpLine, TrashBin } from 'components/common/Icons'
+import useAllAssets from 'hooks/assets/useAllAssets'
+import usePrices from 'hooks/prices/usePrices'
+import useStore from 'store'
+import { calculateAccountBalanceValue } from 'utils/accounts'
+
+interface Props {
+  account: Account
+}
+
+export default function ManageAccount(props: Props) {
+  const { account } = props
+  const assets = useAllAssets()
+  const { data: prices } = usePrices()
+  const isHls = account.kind === 'high_levered_strategy'
+  const positionBalance = useMemo(
+    () => (!account ? null : calculateAccountBalanceValue(account, prices, assets)),
+    [account, assets, prices],
+  )
+  const deleteAccountHandler = useCallback(() => {
+    if (!account) return
+    useStore.setState({ accountDeleteModal: account })
+  }, [account])
+
+  return (
+    <div className='flex flex-wrap justify-center w-full gap-4 md:justify-end'>
+      {!isHls && (
+        <>
+          <Button
+            text='Fund'
+            color='tertiary'
+            leftIcon={<ArrowUpLine />}
+            disabled={!positionBalance}
+            onClick={() => {
+              if (!positionBalance) return
+              if (positionBalance.isLessThanOrEqualTo(0)) {
+                useStore.setState({
+                  focusComponent: {
+                    component: <AccountFundFullPage />,
+                    onClose: () => {
+                      useStore.setState({ getStartedModal: true })
+                    },
+                  },
+                })
+                return
+              }
+              useStore.setState({ fundAndWithdrawModal: 'fund' })
+            }}
+          />
+          <Button
+            color='tertiary'
+            leftIcon={<ArrowDownLine />}
+            text='Withdraw'
+            onClick={() => {
+              useStore.setState({ fundAndWithdrawModal: 'withdraw' })
+            }}
+            disabled={!positionBalance || positionBalance.isLessThanOrEqualTo(0)}
+          />
+        </>
+      )}
+      <Button
+        color='tertiary'
+        leftIcon={<TrashBin />}
+        text='Delete'
+        disabled={!account}
+        onClick={() => {
+          deleteAccountHandler()
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/portfolio/Account/PerpPositions.tsx
+++ b/src/components/portfolio/Account/PerpPositions.tsx
@@ -4,16 +4,14 @@ import AccountPerpPositionTable from 'components/account/AccountPerpPositionTabl
 import Card from 'components/common/Card'
 import TableSkeleton from 'components/common/Table/TableSkeleton'
 import Text from 'components/common/Text'
-import useAccount from 'hooks/accounts/useAccount'
 
 interface Props {
-  accountId: string
+  account: Account
 }
 
 function Content(props: Props) {
-  const { data: account } = useAccount(props.accountId, true)
-
-  if (!account || account.perps.length === 0) return null
+  const { account } = props
+  if (account.perps.length === 0) return null
 
   return (
     <Skeleton>

--- a/src/components/portfolio/Account/Strategies.tsx
+++ b/src/components/portfolio/Account/Strategies.tsx
@@ -4,16 +4,15 @@ import AccountStrategiesTable from 'components/account/AccountStrategiesTable'
 import Card from 'components/common/Card'
 import TableSkeleton from 'components/common/Table/TableSkeleton'
 import Text from 'components/common/Text'
-import useAccount from 'hooks/accounts/useAccount'
 
 interface Props {
-  accountId: string
+  account: Account
 }
 
 function Content(props: Props) {
-  const { data: account } = useAccount(props.accountId, true)
+  const { account } = props
 
-  if (!account || account?.vaults.length === 0) {
+  if (account.vaults.length === 0) {
     return null
   }
 

--- a/src/components/portfolio/Account/Summary.tsx
+++ b/src/components/portfolio/Account/Summary.tsx
@@ -6,22 +6,21 @@ import { FormattedNumber } from 'components/common/FormattedNumber'
 import useLendingMarketAssetsTableData from 'components/earn/lend/Table/useLendingMarketAssetsTableData'
 import Skeleton from 'components/portfolio/SummarySkeleton'
 import { MAX_AMOUNT_DECIMALS } from 'constants/math'
-import useAccount from 'hooks/accounts/useAccount'
 import useAllAssets from 'hooks/assets/useAllAssets'
+import useHealthComputer from 'hooks/health-computer/useHealthComputer'
 import useHLSStakingAssets from 'hooks/hls/useHLSStakingAssets'
 import usePrices from 'hooks/prices/usePrices'
-import useHealthComputer from 'hooks/health-computer/useHealthComputer'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
 import { getAccountSummaryStats } from 'utils/accounts'
 import { DEFAULT_PORTFOLIO_STATS } from 'utils/constants'
 
 interface Props {
-  accountId: string
+  account: Account
   v1?: boolean
 }
 
 function Content(props: Props) {
-  const { data: account } = useAccount(props.accountId, true)
+  const { account } = props
   const { data: prices } = usePrices()
   const { data: vaultAprs } = useVaultAprs()
   const { health, healthFactor } = useHealthComputer(account)
@@ -89,8 +88,8 @@ function Content(props: Props) {
       stats={stats}
       health={health}
       healthFactor={healthFactor}
-      title={props.v1 ? 'V1 Portfolio' : `Credit Account ${props.accountId}`}
-      accountId={props.accountId}
+      title={props.v1 ? 'V1 Portfolio' : `Credit Account ${account.id}`}
+      accountId={account.id}
     />
   )
 }
@@ -102,8 +101,8 @@ export default function Summary(props: Props) {
         <Skeleton
           health={0}
           healthFactor={0}
-          title={`Credit Account ${props.accountId}`}
-          accountId={props.accountId}
+          title={`Credit Account ${props.account.id}`}
+          accountId={props.account.id}
         />
       }
     >

--- a/src/pages/PortfolioAccountPage.tsx
+++ b/src/pages/PortfolioAccountPage.tsx
@@ -3,32 +3,39 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import ShareBar from 'components/common/ShareBar'
 import Balances from 'components/portfolio/Account/Balances'
 import BreadCrumbs from 'components/portfolio/Account/BreadCrumbs'
+import ManageAccount from 'components/portfolio/Account/ManageAccount'
 import PerpPositions from 'components/portfolio/Account/PerpPositions'
 import Strategies from 'components/portfolio/Account/Strategies'
 import Summary from 'components/portfolio/Account/Summary'
-import useAccountId from 'hooks/accounts/useAccountId'
+import useAccount from 'hooks/accounts/useAccount'
+import useAccountIds from 'hooks/accounts/useAccountIds'
 import useChainConfig from 'hooks/chain/useChainConfig'
+import useStore from 'store'
 import { getRoute } from 'utils/route'
 
 export default function PortfolioAccountPage() {
   const chainConfig = useChainConfig()
-  const selectedAccountId = useAccountId()
-  const { address, accountId } = useParams()
+  const { urlAddress, accountId } = useParams()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
+  const address = useStore((s) => s.address)
+  const { data: accountIds } = useAccountIds(address)
+  const isUsersAccount = accountId && accountIds ? accountIds.includes(accountId) : false
+  const { data: account } = useAccount(accountId, true)
 
-  if (!accountId) {
-    navigate(getRoute('portfolio', searchParams, address, selectedAccountId))
+  if (!accountId || !account) {
+    navigate(getRoute('portfolio', searchParams, urlAddress))
     return null
   }
 
   return (
     <div className='flex flex-wrap w-full gap-6'>
       <BreadCrumbs accountId={accountId} />
-      <Summary accountId={accountId} />
-      <Balances accountId={accountId} />
-      {chainConfig.farm && <Strategies accountId={accountId} />}
-      {chainConfig.perps && <PerpPositions accountId={accountId} />}
+      <Summary account={account} />
+      {isUsersAccount && <ManageAccount account={account} />}
+      <Balances account={account} isUsersAccount={isUsersAccount} />
+      {chainConfig.farm && <Strategies account={account} />}
+      {chainConfig.perps && <PerpPositions account={account} />}
       <ShareBar text={`Have a look at Credit Account ${accountId} on @mars_protocol!`} />
     </div>
   )

--- a/src/pages/V1Page.tsx
+++ b/src/pages/V1Page.tsx
@@ -2,14 +2,18 @@ import Summary from 'components/portfolio/Account/Summary'
 import Borrowings from 'components/v1/Borrowings'
 import Deposits from 'components/v1/Deposits'
 import V1Intro from 'components/v1/V1Intro'
+import useAccount from 'hooks/accounts/useAccount'
 import useStore from 'store'
 
 export default function V1Page() {
   const address = useStore((s) => s.address)
+  const { data: account } = useAccount(address)
+
+  if (!account) return null
   return (
     <div className='flex flex-wrap w-full gap-6'>
       <V1Intro />
-      {address && <Summary accountId={address} v1 />}
+      {address && <Summary account={account} v1 />}
       <div className='grid w-full grid-cols-1 gap-6 lg:grid-cols-2'>
         <Deposits />
         <Borrowings />


### PR DESCRIPTION
- Removed the `Fund Account` Button on empty HLS accounts
- Added buttons to manage an Account in the Portfolio Detail view, if the viewer is the owner of that account
- Refactored the usage of `useAccount` in the portfolio account page