### PR TITLE
Fix liquidation price fetching spam

### DIFF
--- a/src/components/account/AccountBalancesTable/Columns/LiqPrice.tsx
+++ b/src/components/account/AccountBalancesTable/Columns/LiqPrice.tsx
@@ -6,7 +6,6 @@ import Text from 'components/common/Text'
 import { Tooltip } from 'components/common/Tooltip'
 import useLiquidationPrice from 'hooks/prices/useLiquidationPrice'
 import { BNCoin } from 'types/classes/BNCoin'
-import { byDenom } from 'utils/array'
 import { LiquidationPriceKind } from 'utils/health_computer'
 import { BN } from 'utils/helpers'
 
@@ -22,18 +21,16 @@ interface Props {
   denom: string
   type: PositionType
   account: Account
-  whitelistedAssets: Asset[]
 }
 
 export default function LiqPrice(props: Props) {
-  const { denom, type, amount, account, computeLiquidationPrice, whitelistedAssets } = props
+  const { denom, type, amount, account, computeLiquidationPrice } = props
   const hasDebt = account.debts.length > 0
 
   const liqPrice = useMemo(() => {
-    const asset = whitelistedAssets.find(byDenom(denom))
-    if (type === 'vault' || !asset || amount === 0) return 0
+    if (type === 'vault' || amount === 0) return 0
     return computeLiquidationPrice(denom, type === 'borrow' ? 'debt' : 'asset')
-  }, [amount, computeLiquidationPrice, denom, type, whitelistedAssets])
+  }, [amount, computeLiquidationPrice, denom, type])
 
   const { liquidationPrice } = useLiquidationPrice(liqPrice)
 

--- a/src/components/account/AccountBalancesTable/Columns/useAccountBalancesColumns.tsx
+++ b/src/components/account/AccountBalancesTable/Columns/useAccountBalancesColumns.tsx
@@ -13,7 +13,6 @@ import Value, {
   VALUE_META,
   valueBalancesSortingFn,
 } from 'components/account/AccountBalancesTable/Columns/Value'
-import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useHealthComputer from 'hooks/health-computer/useHealthComputer'
 import useMarkets from 'hooks/markets/useMarkets'
 import useStore from 'store'
@@ -23,7 +22,6 @@ export default function useAccountBalancesColumns(
   showLiquidationPrice?: boolean,
 ) {
   const markets = useMarkets()
-  const whitelistedAssets = useWhitelistedAssets()
 
   const updatedAccount = useStore((s) => s.updatedAccount)
 
@@ -85,7 +83,6 @@ export default function useAccountBalancesColumns(
                   type={row.original.type}
                   amount={row.original.amount.toNumber()}
                   account={updatedAccount ?? account}
-                  whitelistedAssets={whitelistedAssets}
                 />
               ),
             },

--- a/src/components/account/AccountBalancesTable/Columns/useAccountBalancesColumns.tsx
+++ b/src/components/account/AccountBalancesTable/Columns/useAccountBalancesColumns.tsx
@@ -13,8 +13,9 @@ import Value, {
   VALUE_META,
   valueBalancesSortingFn,
 } from 'components/account/AccountBalancesTable/Columns/Value'
-import useMarkets from 'hooks/markets/useMarkets'
+import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useHealthComputer from 'hooks/health-computer/useHealthComputer'
+import useMarkets from 'hooks/markets/useMarkets'
 import useStore from 'store'
 
 export default function useAccountBalancesColumns(
@@ -22,6 +23,7 @@ export default function useAccountBalancesColumns(
   showLiquidationPrice?: boolean,
 ) {
   const markets = useMarkets()
+  const whitelistedAssets = useWhitelistedAssets()
 
   const updatedAccount = useStore((s) => s.updatedAccount)
 
@@ -83,6 +85,7 @@ export default function useAccountBalancesColumns(
                   type={row.original.type}
                   amount={row.original.amount.toNumber()}
                   account={updatedAccount ?? account}
+                  whitelistedAssets={whitelistedAssets}
                 />
               ),
             },

--- a/src/components/account/AccountPerpPositionTable/Columns/useAccountPerpsColumns.tsx
+++ b/src/components/account/AccountPerpPositionTable/Columns/useAccountPerpsColumns.tsx
@@ -8,13 +8,11 @@ import Value, {
 } from 'components/account/AccountBalancesTable/Columns/Value'
 import Asset, { ASSET_META } from 'components/account/AccountPerpPositionTable/Columns/Asset'
 import TotalPnL, { PNL_META } from 'components/account/AccountPerpPositionTable/Columns/TotalPnL'
-import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useHealthComputer from 'hooks/health-computer/useHealthComputer'
 import useStore from 'store'
 
 export default function useAccountPerpsColumns(account: Account, showLiquidationPrice?: boolean) {
   const updatedAccount = useStore((s) => s.updatedAccount)
-  const whitelistedAssets = useWhitelistedAssets()
   const { computeLiquidationPrice } = useHealthComputer(updatedAccount ?? account)
 
   return useMemo<ColumnDef<AccountPerpRow>[]>(() => {
@@ -41,7 +39,6 @@ export default function useAccountPerpsColumns(account: Account, showLiquidation
             type='perp'
             amount={row.original.amount.toNumber()}
             account={updatedAccount ?? account}
-            whitelistedAssets={whitelistedAssets}
           />
         ),
       },

--- a/src/components/account/AccountPerpPositionTable/Columns/useAccountPerpsColumns.tsx
+++ b/src/components/account/AccountPerpPositionTable/Columns/useAccountPerpsColumns.tsx
@@ -8,12 +8,13 @@ import Value, {
 } from 'components/account/AccountBalancesTable/Columns/Value'
 import Asset, { ASSET_META } from 'components/account/AccountPerpPositionTable/Columns/Asset'
 import TotalPnL, { PNL_META } from 'components/account/AccountPerpPositionTable/Columns/TotalPnL'
+import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useHealthComputer from 'hooks/health-computer/useHealthComputer'
 import useStore from 'store'
 
 export default function useAccountPerpsColumns(account: Account, showLiquidationPrice?: boolean) {
   const updatedAccount = useStore((s) => s.updatedAccount)
-
+  const whitelistedAssets = useWhitelistedAssets()
   const { computeLiquidationPrice } = useHealthComputer(updatedAccount ?? account)
 
   return useMemo<ColumnDef<AccountPerpRow>[]>(() => {
@@ -40,6 +41,7 @@ export default function useAccountPerpsColumns(account: Account, showLiquidation
             type='perp'
             amount={row.original.amount.toNumber()}
             account={updatedAccount ?? account}
+            whitelistedAssets={whitelistedAssets}
           />
         ),
       },

--- a/src/hooks/health-computer/useHealthComputer.ts
+++ b/src/hooks/health-computer/useHealthComputer.ts
@@ -21,16 +21,17 @@ import {
 import { convertAccountToPositions } from 'utils/accounts'
 import { byDenom } from 'utils/array'
 import { SWAP_FEE_BUFFER } from 'utils/constants'
+import { findPositionInAccount } from 'utils/healthComputer'
 import {
   BorrowTarget,
+  LiquidationPriceKind,
+  SwapKind,
   compute_health_js,
   liquidation_price_js,
-  LiquidationPriceKind,
   max_borrow_estimate_js,
   max_perp_size_estimate_js,
   max_swap_estimate_js,
   max_withdraw_estimate_js,
-  SwapKind,
 } from 'utils/health_computer'
 import { BN } from 'utils/helpers'
 import { getTokenPrice } from 'utils/tokens'
@@ -256,7 +257,8 @@ export default function useHealthComputer(account?: Account) {
       if (!healthComputer) return null
       try {
         const asset = whitelistedAsset.find(byDenom(denom))
-        if (!asset) return null
+        const assetInAccount = findPositionInAccount(healthComputer, denom)
+        if (!asset || !assetInAccount) return 0
         const decimalDiff = asset.decimals - PRICE_ORACLE_DECIMALS
         return BN(liquidation_price_js(healthComputer, denom, kind))
           .shiftedBy(-VALUE_SCALE_FACTOR)

--- a/src/utils/healthComputer.ts
+++ b/src/utils/healthComputer.ts
@@ -1,0 +1,15 @@
+import { HealthComputer } from 'types/generated/mars-rover-health-computer/MarsRoverHealthComputer.types'
+
+export function findPositionInAccount(healthComputer: HealthComputer, denom: string) {
+  const positions = [
+    ...healthComputer.positions.debts,
+    ...healthComputer.positions.deposits,
+    ...healthComputer.positions.lends,
+  ]
+  const hasAccountPosition = positions.find((position) => position.denom === denom)
+  const hasPerpPosition = healthComputer.positions.perps.find(
+    (position) => position.denom === denom,
+  )
+
+  return hasAccountPosition || hasPerpPosition
+}


### PR DESCRIPTION
This PR solves the issue with `computeLiquidationPrice` spamming when it tries to get a liquidation price for an unknown or non existent asset (when asset is selected in trade but no amount is chosen) in the Credit Account.