### PR TITLE
fix: fixed the price impact and trade endpoint of neutron

### DIFF
--- a/src/chains/neutron/pion-1.ts
+++ b/src/chains/neutron/pion-1.ts
@@ -22,7 +22,7 @@ const Pion1: ChainConfig = {
     pyth: 'neutron15ldst8t80982akgr8w8ekcytejzkmfpgdkeq4xgtge48qs7435jqp87u3t',
   },
   endpoints: {
-    routes: 'https://app.astroport.fi/api/routes',
+    routes: 'https://testnet.astroport.fi/api/routes',
     rpc: process.env.NEXT_PUBLIC_NEUTRON_TEST_RPC ?? 'https://rpc-palvus.pion-1.ntrn.tech',
     rest: process.env.NEXT_PUBLIC_NEUTRON_TEST_REST ?? 'https://rest-palvus.pion-1.ntrn.tech',
     swap: 'https://testnet-neutron.astroport.fi/swap',

--- a/src/components/trade/TradeModule/SwapForm/TradeSummary.tsx
+++ b/src/components/trade/TradeModule/SwapForm/TradeSummary.tsx
@@ -140,7 +140,7 @@ export default function TradeSummary(props: Props) {
             <SummaryLine label='Price impact' className='mt-2'>
               {routeInfo?.priceImpact ? (
                 <FormattedNumber
-                  amount={routeInfo?.priceImpact.times(100).toNumber() || 0}
+                  amount={routeInfo?.priceImpact.toNumber() || 0}
                   options={{ suffix: '%' }}
                 />
               ) : (

--- a/src/hooks/trade/useRouteInfo.ts
+++ b/src/hooks/trade/useRouteInfo.ts
@@ -24,7 +24,7 @@ export default function useRouteInfo(denomIn: string, denomOut: string, amount: 
 
         return {
           amountOut: BN(route.amount_out),
-          priceImpact: BN(route.price_impact),
+          priceImpact: BN(route.price_impact).times(100),
           fee: BN(route.effective_fee),
           description: [
             assets.find(byDenom(denomIn))?.symbol,


### PR DESCRIPTION
- Astroport reports price impact via a percent value while Osmosis reports percentage points
- Replaced the routes endpoint for testnet