### PR TITLE
Hotfix Debounce

### DIFF
--- a/src/components/Modals/AssetAmountSelectActionModal.tsx
+++ b/src/components/Modals/AssetAmountSelectActionModal.tsx
@@ -25,7 +25,6 @@ interface Props {
   onClose: () => void
   onChange: (value: BigNumber) => void
   onAction: (value: BigNumber, isMax: boolean) => void
-  onDebounce: () => void
 }
 
 export default function AssetAmountSelectActionModal(props: Props) {
@@ -39,7 +38,6 @@ export default function AssetAmountSelectActionModal(props: Props) {
     onClose,
     onChange,
     onAction,
-    onDebounce,
   } = props
   const [amount, setAmount] = useState(BN_ZERO)
   const maxAmount = BN(coinBalances.find(byDenom(asset.denom))?.amount ?? 0)
@@ -82,7 +80,6 @@ export default function AssetAmountSelectActionModal(props: Props) {
           <TokenInputWithSlider
             asset={asset}
             onChange={handleAmountChange}
-            onDebounce={onDebounce}
             amount={amount}
             max={maxAmount}
             hasSelect

--- a/src/components/Modals/LendAndReclaim/index.tsx
+++ b/src/components/Modals/LendAndReclaim/index.tsx
@@ -39,15 +39,12 @@ function LendAndReclaimModal({ currentAccount, config }: Props) {
 
   const handleAmountChange = useCallback(
     (value: BigNumber) => {
-      setCoin(BNCoin.fromDenomAndBigNumber(asset.denom, value))
+      const newCoin = BNCoin.fromDenomAndBigNumber(asset.denom, value)
+      setCoin(newCoin)
+      simulateLending(isLendAction, newCoin)
     },
-    [asset.denom],
+    [asset.denom, isLendAction, simulateLending],
   )
-
-  const onDebounce = useCallback(() => {
-    if (!coin) return
-    simulateLending(isLendAction, coin)
-  }, [coin, isLendAction, simulateLending])
 
   const handleAction = useCallback(
     (value: BigNumber, isMax: boolean) => {
@@ -79,7 +76,6 @@ function LendAndReclaimModal({ currentAccount, config }: Props) {
       onClose={close}
       onAction={handleAction}
       onChange={handleAmountChange}
-      onDebounce={onDebounce}
     />
   )
 }

--- a/src/components/Modals/v1/Borrow.tsx
+++ b/src/components/Modals/v1/Borrow.tsx
@@ -57,18 +57,16 @@ export default function Borrow(props: Props) {
 
   const handleChange = useCallback(
     (newAmount: BigNumber) => {
-      if (!amount.isEqualTo(newAmount)) setAmount(newAmount)
+      if (amount.isEqualTo(newAmount)) return
+      setAmount(newAmount)
+      const borrowCoin = BNCoin.fromDenomAndBigNumber(
+        asset.denom,
+        newAmount.isGreaterThan(max) ? max : newAmount,
+      )
+      simulateBorrow('wallet', borrowCoin)
     },
-    [amount, setAmount],
+    [amount, asset.denom, max, simulateBorrow],
   )
-
-  const onDebounce = useCallback(() => {
-    const borrowCoin = BNCoin.fromDenomAndBigNumber(
-      asset.denom,
-      amount.isGreaterThan(max) ? max : amount,
-    )
-    simulateBorrow('wallet', borrowCoin)
-  }, [amount, max, asset, simulateBorrow])
 
   const maxBorrow = useMemo(() => {
     const maxBorrowAmount = computeMaxBorrowAmount(asset.denom, 'wallet')
@@ -162,7 +160,6 @@ export default function Borrow(props: Props) {
           <TokenInputWithSlider
             asset={asset}
             onChange={handleChange}
-            onDebounce={onDebounce}
             amount={amount}
             max={max}
             disabled={max.isZero()}

--- a/src/components/Modals/v1/Deposit.tsx
+++ b/src/components/Modals/v1/Deposit.tsx
@@ -51,15 +51,13 @@ export default function Deposit(props: Props) {
     }
   }, [baseBalance])
 
-  const onDebounce = useCallback(() => {
-    simulateDeposits('lend', [fundingAsset])
-  }, [fundingAsset, simulateDeposits])
-
   const handleAmountChange = useCallback(
     (value: BigNumber) => {
-      setFundingAsset(BNCoin.fromDenomAndBigNumber(asset.denom, value))
+      const newFundingAsset = BNCoin.fromDenomAndBigNumber(asset.denom, value)
+      setFundingAsset(newFundingAsset)
+      simulateDeposits('lend', [newFundingAsset])
     },
-    [asset.denom],
+    [asset.denom, simulateDeposits],
   )
 
   if (!modal) return
@@ -75,7 +73,6 @@ export default function Deposit(props: Props) {
       onClose={close}
       onAction={handleClick}
       onChange={handleAmountChange}
-      onDebounce={onDebounce}
     />
   )
 }

--- a/src/components/Modals/v1/Repay.tsx
+++ b/src/components/Modals/v1/Repay.tsx
@@ -92,17 +92,14 @@ export default function Repay(props: Props) {
   const handleChange = useCallback(
     (newAmount: BigNumber) => {
       if (!amount.isEqualTo(newAmount)) setAmount(newAmount)
+      const repayCoin = BNCoin.fromDenomAndBigNumber(
+        asset.denom,
+        newAmount.isGreaterThan(accountDebt) ? accountDebt : newAmount,
+      )
+      simulateRepay(repayCoin, true)
     },
-    [amount, setAmount],
+    [accountDebt, amount, asset.denom, simulateRepay],
   )
-
-  const onDebounce = useCallback(() => {
-    const repayCoin = BNCoin.fromDenomAndBigNumber(
-      asset.denom,
-      amount.isGreaterThan(accountDebt) ? accountDebt : amount,
-    )
-    simulateRepay(repayCoin, true)
-  }, [amount, accountDebt, asset, simulateRepay])
 
   useEffect(() => {
     if (maxRepayAmount.isEqualTo(max)) return
@@ -188,7 +185,6 @@ export default function Repay(props: Props) {
           <TokenInputWithSlider
             asset={asset}
             onChange={handleChange}
-            onDebounce={onDebounce}
             amount={amount}
             max={max}
             disabled={max.isZero()}

--- a/src/components/Modals/v1/Withdraw.tsx
+++ b/src/components/Modals/v1/Withdraw.tsx
@@ -40,15 +40,14 @@ export default function Withdraw(props: Props) {
     close()
   }, [v1Action, withdrawAsset, close])
 
-  const onDebounce = useCallback(() => {
-    simulateWithdraw(false, withdrawAsset)
-  }, [withdrawAsset, simulateWithdraw])
-
   const handleAmountChange = useCallback(
     (value: BigNumber) => {
-      setWithdrawAsset(BNCoin.fromDenomAndBigNumber(asset.denom, value))
+      const newWithdrawAsset = BNCoin.fromDenomAndBigNumber(asset.denom, value)
+      setWithdrawAsset(newWithdrawAsset)
+
+      simulateWithdraw(false, newWithdrawAsset)
     },
-    [asset.denom],
+    [asset.denom, simulateWithdraw],
   )
 
   if (!modal) return
@@ -64,7 +63,6 @@ export default function Withdraw(props: Props) {
       onClose={close}
       onAction={handleClick}
       onChange={handleAmountChange}
-      onDebounce={onDebounce}
     />
   )
 }

--- a/src/components/account/AccountFund/AccountFundContent.tsx
+++ b/src/components/account/AccountFund/AccountFundContent.tsx
@@ -110,19 +110,19 @@ export default function AccountFundContent(props: Props) {
     setFundingAssets(newFundingAssets)
   }, [selectedDenoms, fundingAssets])
 
-  const updateFundingAssets = useCallback((amount: BigNumber, denom: string) => {
-    setFundingAssets((fundingAssets) => {
-      const updateIdx = fundingAssets.findIndex(byDenom(denom))
-      if (updateIdx === -1) return fundingAssets
+  const updateFundingAssets = useCallback(
+    (amount: BigNumber, denom: string) => {
+      setFundingAssets((fundingAssets) => {
+        const updateIdx = fundingAssets.findIndex(byDenom(denom))
+        if (updateIdx === -1) return fundingAssets
 
-      fundingAssets[updateIdx].amount = amount
-      return [...fundingAssets]
-    })
-  }, [])
-
-  const onDebounce = useCallback(() => {
-    simulateDeposits(isLending ? 'lend' : 'deposit', fundingAssets)
-  }, [isLending, fundingAssets, simulateDeposits])
+        fundingAssets[updateIdx].amount = amount
+        simulateDeposits(isLending ? 'lend' : 'deposit', fundingAssets)
+        return [...fundingAssets]
+      })
+    },
+    [isLending, simulateDeposits],
+  )
 
   const depositCapReachedCoins = useMemo(() => {
     const depositCapReachedCoins: BNCoin[] = []
@@ -158,7 +158,6 @@ export default function AccountFundContent(props: Props) {
                 amount={coin.amount ?? BN_ZERO}
                 isConfirming={isConfirming}
                 updateFundingAssets={updateFundingAssets}
-                onDebounce={onDebounce}
               />
             </div>
           )

--- a/src/components/account/AccountFund/AccountFundRow.tsx
+++ b/src/components/account/AccountFund/AccountFundRow.tsx
@@ -10,7 +10,6 @@ interface Props {
   denom: string
   isConfirming: boolean
   updateFundingAssets: (amount: BigNumber, denom: string) => void
-  onDebounce: () => void
 }
 
 export default function AccountFundRow(props: Props) {
@@ -24,7 +23,6 @@ export default function AccountFundRow(props: Props) {
     <TokenInputWithSlider
       asset={asset}
       onChange={(amount) => props.updateFundingAssets(amount, asset.denom)}
-      onDebounce={props.onDebounce}
       amount={props.amount}
       max={balance}
       balances={props.balances}

--- a/src/components/common/Slider/index.tsx
+++ b/src/components/common/Slider/index.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames'
-import debounce from 'lodash.debounce'
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Draggable from 'react-draggable'
 
@@ -12,7 +11,6 @@ import useToggle from 'hooks/common/useToggle'
 type Props = {
   value: number
   onChange: (value: number) => void
-  onDebounce?: () => void
   leverage?: {
     current: number
     max: number
@@ -22,7 +20,7 @@ type Props = {
 }
 
 export default function Slider(props: Props) {
-  const { value, onChange, onDebounce, leverage, className, disabled } = props
+  const { value, onChange, leverage, className, disabled } = props
   const [newValue, setNewValue] = useState(value)
   const [showTooltip, setShowTooltip] = useToggle()
   const [sliderRect, setSliderRect] = useState({ width: 0, left: 0, right: 0 })
@@ -48,20 +46,10 @@ export default function Slider(props: Props) {
     }
   }, [sliderRect.left, sliderRect.right, sliderRect.width])
 
-  const debounceFunction = useMemo(
-    () =>
-      debounce(() => {
-        if (!onDebounce) return
-        onDebounce()
-      }, 250),
-    [onDebounce],
-  )
-
   function handleOnChange(value: number) {
     if (value === newValue) return
     setNewValue(value)
     onChange(value)
-    debounceFunction()
   }
 
   function handleDrag(e: any) {

--- a/src/components/common/TokenInput/TokenInputWithSlider.tsx
+++ b/src/components/common/TokenInput/TokenInputWithSlider.tsx
@@ -12,7 +12,6 @@ interface Props {
   asset: Asset
   max: BigNumber
   onChange: (amount: BigNumber) => void
-  onDebounce?: () => void
   accountId?: string
   balances?: BNCoin[]
   className?: string
@@ -33,14 +32,7 @@ export default function TokenInputWithSlider(props: Props) {
 
   function onChangeSlider(percentage: number) {
     const newAmount = BN(percentage).dividedBy(100).multipliedBy(props.max).integerValue()
-    setPercentage(percentage)
-    setAmount(newAmount)
-    props.onChange(newAmount)
-  }
-
-  function onDebounce() {
-    if (!props.onDebounce) return
-    props.onDebounce()
+    onChangeAmount(newAmount)
   }
 
   function onChangeAmount(newAmount: BigNumber) {
@@ -82,7 +74,6 @@ export default function TokenInputWithSlider(props: Props) {
       <Slider
         value={percentage || 0}
         onChange={(value) => onChangeSlider(value)}
-        onDebounce={onDebounce}
         disabled={props.disabled}
         leverage={props.leverage}
       />


### PR DESCRIPTION
This PR removes the debounce on the `TokenInputSlider.`

After testing several scenarios, it became evident that the `debounceFunction` causes significant issues when used in combination with the input field, particularly on the 'TokenInputWithSlider '. 
The simulations did not recognize manual inputs, and moving the slider to 0 or any other value did not represent the correct amount in the updated account simulation. 

Removing the debounce did not harm the dApp's performance, as other improvements that removed some excessive rendering were made in previous pull requests.

This hotfix fixes all issues that the community reported regarding the `TokenInputWithSlider` component.