### PR TITLE
Feature/account minting abstraction

### DIFF
--- a/src/components/account/AccountCreateFirst.tsx
+++ b/src/components/account/AccountCreateFirst.tsx
@@ -9,47 +9,51 @@ import useStore from 'store'
 import { getPage, getRoute } from 'utils/route'
 
 export default function AccountCreateFirst() {
-  const navigate = useNavigate()
-  const { pathname } = useLocation()
-  const address = useStore((s) => s.address)
-  const createAccount = useStore((s) => s.createAccount)
-  const [isCreating, setIsCreating] = useToggle(false)
-  const [searchParams] = useSearchParams()
-
-  useEffect(() => {
-    if (!address) useStore.setState({ focusComponent: { component: <WalletSelect /> } })
-  }, [address])
-
-  const handleClick = useCallback(async () => {
-    setIsCreating(true)
-    const accountId = await createAccount('default')
-    setIsCreating(false)
-    if (accountId) {
-      navigate(getRoute(getPage(pathname), searchParams, address, accountId))
-      useStore.setState({
-        focusComponent: {
-          component: <AccountFundFullPage />,
-          onClose: () => {
-            useStore.setState({ getStartedModal: true })
-          },
-        },
-      })
-    }
-  }, [setIsCreating, createAccount, navigate, pathname, searchParams, address])
-
-  return (
-    <FullOverlayContent
-      title='Mint your account'
-      copy="We'll require you to authorise a transaction in your wallet in order to begin."
-      button={{
-        className: 'mt-4 w-full',
-        text: 'Approve transaction',
-        color: 'tertiary',
-        showProgressIndicator: isCreating,
-        onClick: handleClick,
-        size: 'lg',
-      }}
-      docs='account'
-    />
-  )
+  return <AccountFundFullPage hasExistingAccount={false} />
 }
+
+// export default function AccountCreateFirst() {
+//   const navigate = useNavigate()
+//   const { pathname } = useLocation()
+//   const address = useStore((s) => s.address)
+//   const createAccount = useStore((s) => s.createAccount)
+//   const [isCreating, setIsCreating] = useToggle(false)
+//   const [searchParams] = useSearchParams()
+
+//   useEffect(() => {
+//     if (!address) useStore.setState({ focusComponent: { component: <WalletSelect /> } })
+//   }, [address])
+
+//   const handleClick = useCallback(async () => {
+//     setIsCreating(true)
+//     const accountId = await createAccount('default')
+//     setIsCreating(false)
+//     if (accountId) {
+//       navigate(getRoute(getPage(pathname), searchParams, address, accountId))
+//       useStore.setState({
+//         focusComponent: {
+//           component: <AccountFundFullPage hasExistingAccount={false} />,
+//           onClose: () => {
+//             useStore.setState({ getStartedModal: true })
+//           },
+//         },
+//       })
+//     }
+//   }, [setIsCreating, createAccount, navigate, pathname, searchParams, address])
+
+//   return (
+//     <FullOverlayContent
+//       title='Mint your account'
+//       copy="We'll require you to authorise a transaction in your wallet in order to begin."
+//       button={{
+//         className: 'mt-4 w-full',
+//         text: 'Approve transaction',
+//         color: 'tertiary',
+//         showProgressIndicator: isCreating,
+//         onClick: handleClick,
+//         size: 'lg',
+//       }}
+//       docs='account'
+//     />
+//   )
+// }

--- a/src/components/account/AccountCreateFirst.tsx
+++ b/src/components/account/AccountCreateFirst.tsx
@@ -1,59 +1,56 @@
-import { useCallback, useEffect } from 'react'
+import { useEffect } from 'react'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
-import AccountFundFullPage from 'components/account/AccountFund/AccountFundFullPage'
+import AccountFundContent from 'components/account/AccountFund/AccountFundContent'
+import Card from 'components/common/Card'
+import { CircularProgress } from 'components/common/CircularProgress'
 import FullOverlayContent from 'components/common/FullOverlayContent'
 import WalletSelect from 'components/Wallet/WalletSelect'
-import useToggle from 'hooks/common/useToggle'
 import useStore from 'store'
-import { getPage, getRoute } from 'utils/route'
+import useAccounts from 'hooks/accounts/useAccounts'
+import useCurrentAccount from 'hooks/accounts/useCurrentAccount'
+import useAccountId from 'hooks/accounts/useAccountId'
+import { useWeb3WalletConnection } from 'hooks/wallet/useWeb3WalletConnections'
+import useWalletBalances from 'hooks/wallet/useWalletBalances'
 
 export default function AccountCreateFirst() {
-  return <AccountFundFullPage hasExistingAccount={false} />
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+  const [searchParams] = useSearchParams()
+  const address = useStore((s) => s.address)
+  const accountId = useAccountId()
+
+  const { data: accounts, isLoading } = useAccounts('default', address)
+  const currentAccount = useCurrentAccount()
+  const { data: walletBalances } = useWalletBalances(address ?? '')
+  const { handleConnectWallet } = useWeb3WalletConnection()
+
+  useEffect(() => {
+    if (!address) useStore.setState({ focusComponent: { component: <WalletSelect /> } })
+  }, [address])
+
+  const hasExistingAccount = accounts && accounts.length > 0
+
+  return (
+    <FullOverlayContent
+      title={'Create and Fund a Credit Account'}
+      copy='In order to start using this account, you need to deposit funds.'
+      docs='fund'
+    >
+      {isLoading ? (
+        <CircularProgress size={40} />
+      ) : (
+        <Card className='w-full p-6 bg-white/5'>
+          <AccountFundContent
+            account={currentAccount}
+            address={address}
+            accountId=''
+            isFullPage
+            onConnectWallet={handleConnectWallet}
+            hasExistingAccount={hasExistingAccount}
+          />
+        </Card>
+      )}
+    </FullOverlayContent>
+  )
 }
-
-// export default function AccountCreateFirst() {
-//   const navigate = useNavigate()
-//   const { pathname } = useLocation()
-//   const address = useStore((s) => s.address)
-//   const createAccount = useStore((s) => s.createAccount)
-//   const [isCreating, setIsCreating] = useToggle(false)
-//   const [searchParams] = useSearchParams()
-
-//   useEffect(() => {
-//     if (!address) useStore.setState({ focusComponent: { component: <WalletSelect /> } })
-//   }, [address])
-
-//   const handleClick = useCallback(async () => {
-//     setIsCreating(true)
-//     const accountId = await createAccount('default')
-//     setIsCreating(false)
-//     if (accountId) {
-//       navigate(getRoute(getPage(pathname), searchParams, address, accountId))
-//       useStore.setState({
-//         focusComponent: {
-//           component: <AccountFundFullPage hasExistingAccount={false} />,
-//           onClose: () => {
-//             useStore.setState({ getStartedModal: true })
-//           },
-//         },
-//       })
-//     }
-//   }, [setIsCreating, createAccount, navigate, pathname, searchParams, address])
-
-//   return (
-//     <FullOverlayContent
-//       title='Mint your account'
-//       copy="We'll require you to authorise a transaction in your wallet in order to begin."
-//       button={{
-//         className: 'mt-4 w-full',
-//         text: 'Approve transaction',
-//         color: 'tertiary',
-//         showProgressIndicator: isCreating,
-//         onClick: handleClick,
-//         size: 'lg',
-//       }}
-//       docs='account'
-//     />
-//   )
-// }

--- a/src/components/account/AccountFund/AccountFundContent.tsx
+++ b/src/components/account/AccountFund/AccountFundContent.tsx
@@ -23,7 +23,7 @@ import Button from 'components/common/Button'
 
 interface Props {
   account?: Account
-  address: string
+  address?: string
   accountId: string
   isFullPage?: boolean
   onConnectWallet: () => Promise<void>

--- a/src/components/account/AccountFund/AccountFundFullPage.tsx
+++ b/src/components/account/AccountFund/AccountFundFullPage.tsx
@@ -31,11 +31,19 @@ export default function AccountFundFullPage(props: AccountFundFullPageProps) {
     if (accountId && selectedAccountId !== accountId) setSelectedAccountId(accountId)
   }, [accounts, selectedAccountId, accountId, currentAccount])
 
-  if (!selectedAccountId || !address) return null
-
   const title = props.hasExistingAccount
-    ? `Fund Credit Account #${selectedAccountId}`
-    : 'Fund a Credit Account'
+    ? `Fund Credit Account ${selectedAccountId ? `#${selectedAccountId}` : ''}`
+    : 'Create and Fund a Credit Account'
+
+  if (!address) {
+    return (
+      <FullOverlayContent
+        title='Connect Your Wallet'
+        copy='Please connect your wallet to create and fund your account.'
+        docs='fund'
+      />
+    )
+  }
 
   return (
     <FullOverlayContent
@@ -50,7 +58,7 @@ export default function AccountFundFullPage(props: AccountFundFullPageProps) {
           <AccountFundContent
             account={currentAccount}
             address={address}
-            accountId={selectedAccountId}
+            accountId={selectedAccountId ?? ''}
             isFullPage
             onConnectWallet={handleConnectWallet}
             hasExistingAccount={props.hasExistingAccount}

--- a/src/components/account/AccountFund/AccountFundFullPage.tsx
+++ b/src/components/account/AccountFund/AccountFundFullPage.tsx
@@ -11,7 +11,11 @@ import useStore from 'store'
 import { useWeb3WalletConnection } from 'hooks/wallet/useWeb3WalletConnections'
 import useWalletBalances from 'hooks/wallet/useWalletBalances'
 
-export default function AccountFundFullPage() {
+interface AccountFundFullPageProps {
+  hasExistingAccount?: boolean
+}
+
+export default function AccountFundFullPage(props: AccountFundFullPageProps) {
   const address = useStore((s) => s.address)
   const accountId = useAccountId()
 
@@ -29,9 +33,13 @@ export default function AccountFundFullPage() {
 
   if (!selectedAccountId || !address) return null
 
+  const title = props.hasExistingAccount
+    ? `Fund Credit Account #${selectedAccountId}`
+    : 'Fund a Credit Account'
+
   return (
     <FullOverlayContent
-      title={`Fund Credit Account #${selectedAccountId}`}
+      title={title}
       copy='In order to start using this account, you need to deposit funds.'
       docs='fund'
     >
@@ -45,6 +53,7 @@ export default function AccountFundFullPage() {
             accountId={selectedAccountId}
             isFullPage
             onConnectWallet={handleConnectWallet}
+            hasExistingAccount={props.hasExistingAccount}
           />
         </Card>
       )}

--- a/src/components/account/AccountMenuContent.tsx
+++ b/src/components/account/AccountMenuContent.tsx
@@ -44,8 +44,7 @@ export default function AccountMenuContent(props: Props) {
   const { enableAutoLendAccountId } = useAutoLend()
 
   const hasCreditAccounts = !!accountIds?.length
-  const isAccountSelected =
-    hasCreditAccounts && accountId && isNumber(accountId) && accountIds.includes(accountId)
+  const isAccountSelected = hasCreditAccounts && accountId && accountIds.includes(accountId)
 
   const performCreateAccount = useCallback(async () => {
     setShowMenu(false)

--- a/src/store/slices/broadcast.ts
+++ b/src/store/slices/broadcast.ts
@@ -19,20 +19,18 @@ import { ExecuteMsg as IncentivesExecuteMsg } from 'types/generated/mars-incenti
 import { ExecuteMsg as RedBankExecuteMsg } from 'types/generated/mars-red-bank/MarsRedBank.types'
 import { AccountKind } from 'types/generated/mars-rover-health-types/MarsRoverHealthTypes.types'
 import { byDenom, bySymbol } from 'utils/array'
-import { generateErrorMessage, getSingleValueFromBroadcastResult, sortFunds } from 'utils/broadcast'
+import {
+  generateCreditAccountId,
+  generateErrorMessage,
+  getSingleValueFromBroadcastResult,
+  sortFunds,
+} from 'utils/broadcast'
 import checkAutoLendEnabled from 'utils/checkAutoLendEnabled'
 import checkPythUpdateEnabled from 'utils/checkPythUpdateEnabled'
 import { defaultFee } from 'utils/constants'
 import { generateToast } from 'utils/generateToast'
 import { BN } from 'utils/helpers'
 import { getSwapExactInAction } from 'utils/swap'
-
-function generateCreditAccountId(): string {
-  const length = Math.floor(Math.random() * (15 - 4 + 1)) + 4
-  return Math.random()
-    .toString(36)
-    .substring(2, 2 + length)
-}
 
 function generateExecutionMessage(
   sender: string | undefined = '',

--- a/src/store/slices/broadcast.ts
+++ b/src/store/slices/broadcast.ts
@@ -27,6 +27,13 @@ import { generateToast } from 'utils/generateToast'
 import { BN } from 'utils/helpers'
 import { getSwapExactInAction } from 'utils/swap'
 
+function generateCreditAccountId(): string {
+  const length = Math.floor(Math.random() * (15 - 4 + 1)) + 4
+  return Math.random()
+    .toString(36)
+    .substring(2, 2 + length)
+}
+
 function generateExecutionMessage(
   sender: string | undefined = '',
   contract: string,
@@ -368,6 +375,56 @@ export default function createBroadcastSlice(
 
       get().handleTransaction({ response })
       return response.then((response) => !!response.result)
+    },
+    createAndFundAccount: async (options: {
+      coins: BNCoin[]
+      lend: boolean
+      kind?: AccountKind
+    }) => {
+      const kind = options.kind || 'default'
+      const accountId = generateCreditAccountId()
+
+      const createMsg: CreditManagerExecuteMsg = {
+        create_credit_account_v2: {
+          kind,
+          account_id: accountId,
+        },
+      }
+
+      const updateMsg: CreditManagerExecuteMsg = {
+        update_credit_account: {
+          account_id: accountId,
+          actions: options.coins.map((coin) => ({
+            deposit: coin.toCoin(),
+          })),
+        },
+      }
+
+      if (options.lend) {
+        updateMsg.update_credit_account.actions.push(
+          ...options.coins
+            .filter((coin) => get().assets.find(byDenom(coin.denom))?.isAutoLendEnabled)
+            .map((coin) => ({ lend: coin.toActionCoin() })),
+        )
+      }
+
+      const funds = options.coins.map((coin) => coin.toCoin())
+      const cmContract = get().chainConfig.contracts.creditManager
+      const response = get().executeMsg({
+        messages: [
+          generateExecutionMessage(get().address, cmContract, createMsg, []),
+          generateExecutionMessage(get().address, cmContract, updateMsg, sortFunds(funds)),
+        ],
+      })
+
+      get().handleTransaction({ response })
+
+      return response.then((response) => {
+        if (response.result) {
+          return accountId
+        }
+        return null
+      })
     },
 
     withdrawFromVaults: async (options: {

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -971,6 +971,11 @@ interface BroadcastSlice {
     accountKind: import('types/generated/mars-rover-health-types/MarsRoverHealthTypes.types').AccountKind,
   ) => Promise<string | null>
   deleteAccount: (options: { accountId: string; lends: BNCoin[] }) => Promise<boolean>
+  createAndFundAccount: (options: {
+    coins: BNCoin[]
+    lend: boolean
+    kind?: AccountKind
+  }) => Promise<string | null>
   deposit: (options: { accountId: string; coins: BNCoin[]; lend: boolean }) => Promise<boolean>
   depositIntoFarm: (options: {
     accountId: string

--- a/src/utils/broadcast.ts
+++ b/src/utils/broadcast.ts
@@ -608,3 +608,10 @@ export function sortFunds(funds: Coin[]) {
   // Transaction on Osmosis fail, if uosmo is not at the last position of the funds array
   return funds.sort((a, b) => a.denom.localeCompare(b.denom))
 }
+
+export function generateCreditAccountId(): string {
+  const length = Math.floor(Math.random() * (15 - 4 + 1)) + 4
+  return Math.random()
+    .toString(36)
+    .substring(2, 2 + length)
+}


### PR DESCRIPTION
This PR streamlines the account creation process by combining the creation and initial funding into a single transaction. It updates the AccountCreateFirst component to bypass the separate minting step and directly use AccountFundFullPage for new accounts. The changes also include updates to handle and display the new alphanumeric account IDs throughout the application, particularly in the navbar and account selection UI.

https://github.com/user-attachments/assets/81110a62-33eb-4289-8ad2-4e6d1b2839db

