### PR TITLE
fix: fix autolend on create

### DIFF
--- a/src/components/Modals/HLS/Deposit/CreateAccount.tsx
+++ b/src/components/Modals/HLS/Deposit/CreateAccount.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { mutate } from 'swr'
 
 import Button from 'components/common/Button'
@@ -14,7 +14,7 @@ export default function CreateAccount() {
 
   async function handleBtnClick() {
     setIsTxPending(true)
-    const response = await createAccount('high_levered_strategy')
+    const response = await createAccount('high_levered_strategy', false)
 
     if (response === null) {
       setIsTxPending(false)
@@ -24,8 +24,8 @@ export default function CreateAccount() {
   }
 
   return (
-    <div id='item-2' className='p-4 flex-col flex'>
-      <Text size='sm' className='text-white/50 mb-4 mt-2'>
+    <div id='item-2' className='flex flex-col p-4'>
+      <Text size='sm' className='mt-2 mb-4 text-white/50'>
         Depositing into a HLS strategy mandates the creation of a HLS credit account.
       </Text>
       <Button

--- a/src/components/Modals/HLS/Deposit/SelectAccount.tsx
+++ b/src/components/Modals/HLS/Deposit/SelectAccount.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames'
-import React from 'react'
 
 import Button from 'components/common/Button'
 import { ArrowRight } from 'components/common/Icons'
@@ -18,7 +17,7 @@ export default function CreateAccount(props: Props) {
   }
 
   return (
-    <div id='item-2' className='flex-col flex'>
+    <div id='item-2' className='flex flex-col'>
       {props.hlsAccounts.map((account, index) => (
         <div
           key={account.id}
@@ -40,7 +39,7 @@ export default function CreateAccount(props: Props) {
         text='Continue'
         rightIcon={<ArrowRight />}
         showProgressIndicator={false}
-        className='mb-2 mx-4 mb-5'
+        className='mx-4 mb-5'
       />
     </div>
   )

--- a/src/components/account/AccountCreateFirst.tsx
+++ b/src/components/account/AccountCreateFirst.tsx
@@ -5,6 +5,7 @@ import AccountFundFullPage from 'components/account/AccountFund/AccountFundFullP
 import FullOverlayContent from 'components/common/FullOverlayContent'
 import WalletSelect from 'components/Wallet/WalletSelect'
 import useToggle from 'hooks/common/useToggle'
+import useEnableAutoLendGlobal from 'hooks/localStorage/useEnableAutoLendGlobal'
 import useStore from 'store'
 import { getPage, getRoute } from 'utils/route'
 
@@ -15,6 +16,7 @@ export default function AccountCreateFirst() {
   const createAccount = useStore((s) => s.createAccount)
   const [isCreating, setIsCreating] = useToggle(false)
   const [searchParams] = useSearchParams()
+  const [isAutoLendEnabled] = useEnableAutoLendGlobal()
 
   useEffect(() => {
     if (!address) useStore.setState({ focusComponent: { component: <WalletSelect /> } })
@@ -22,7 +24,7 @@ export default function AccountCreateFirst() {
 
   const handleClick = useCallback(async () => {
     setIsCreating(true)
-    const accountId = await createAccount('default')
+    const accountId = await createAccount('default', isAutoLendEnabled)
     setIsCreating(false)
     if (accountId) {
       navigate(getRoute(getPage(pathname), searchParams, address, accountId))
@@ -35,7 +37,7 @@ export default function AccountCreateFirst() {
         },
       })
     }
-  }, [setIsCreating, createAccount, navigate, pathname, searchParams, address])
+  }, [setIsCreating, createAccount, isAutoLendEnabled, navigate, pathname, searchParams, address])
 
   return (
     <FullOverlayContent

--- a/src/components/account/AccountMenuContent.tsx
+++ b/src/components/account/AccountMenuContent.tsx
@@ -42,6 +42,7 @@ export default function AccountMenuContent(props: Props) {
   const hasFundsForTxFee = useHasFundsForTxFee()
   const [enableAutoLendGlobal] = useEnableAutoLendGlobal()
   const { enableAutoLendAccountId } = useAutoLend()
+  const [isAutoLendEnabled] = useEnableAutoLendGlobal()
 
   const hasCreditAccounts = !!accountIds?.length
   const isAccountSelected =
@@ -50,7 +51,7 @@ export default function AccountMenuContent(props: Props) {
   const performCreateAccount = useCallback(async () => {
     setShowMenu(false)
     setIsCreating(true)
-    const accountId = await createAccount('default')
+    const accountId = await createAccount('default', isAutoLendEnabled)
     setIsCreating(false)
 
     if (accountId) {
@@ -74,6 +75,7 @@ export default function AccountMenuContent(props: Props) {
     searchParams,
     address,
     enableAutoLendGlobal,
+    isAutoLendEnabled,
     enableAutoLendAccountId,
   ])
 

--- a/src/hooks/wallet/useAutoLend.ts
+++ b/src/hooks/wallet/useAutoLend.ts
@@ -1,6 +1,7 @@
 import useAccounts from 'hooks/accounts/useAccounts'
 import useCurrentAccount from 'hooks/accounts/useCurrentAccount'
 import useAutoLendEnabledAccountIds from 'hooks/localStorage/useAutoLendEnabledAccountIds'
+import { useCallback } from 'react'
 import useStore from 'store'
 
 export default function useAutoLend(): {
@@ -16,33 +17,45 @@ export default function useAutoLend(): {
   const currentAccount = useCurrentAccount()
   const [autoLendEnabledAccountIds, setAutoLendEnabledAccountIds] = useAutoLendEnabledAccountIds()
 
-  const enableAutoLend = (accountId: string) => {
-    const setOfAccountIds = new Set(autoLendEnabledAccountIds)
-    setOfAccountIds.add(accountId)
-    setAutoLendEnabledAccountIds(Array.from(setOfAccountIds))
-  }
+  const enableAutoLend = useCallback(
+    (accountId: string) => {
+      const setOfAccountIds = new Set(autoLendEnabledAccountIds)
+      setOfAccountIds.add(accountId)
+      setAutoLendEnabledAccountIds(Array.from(setOfAccountIds))
+    },
+    [autoLendEnabledAccountIds, setAutoLendEnabledAccountIds],
+  )
 
-  const disableAutoLend = (accountId: string) => {
-    const setOfAccountIds = new Set(autoLendEnabledAccountIds)
-    setOfAccountIds.delete(accountId)
-    setAutoLendEnabledAccountIds(Array.from(setOfAccountIds))
-  }
+  const disableAutoLend = useCallback(
+    (accountId: string) => {
+      const setOfAccountIds = new Set(autoLendEnabledAccountIds)
+      setOfAccountIds.delete(accountId)
+      setAutoLendEnabledAccountIds(Array.from(setOfAccountIds))
+    },
+    [autoLendEnabledAccountIds, setAutoLendEnabledAccountIds],
+  )
 
   const isAutoLendEnabledForCurrentAccount = currentAccount
     ? autoLendEnabledAccountIds.includes(currentAccount.id)
     : false
 
-  const setAutoLendOnAllAccounts = (lendAssets: boolean) => {
-    const allAccountIds = accounts ? accounts.map((account) => account.id) : []
-    setAutoLendEnabledAccountIds(lendAssets ? allAccountIds : [])
-  }
+  const setAutoLendOnAllAccounts = useCallback(
+    (lendAssets: boolean) => {
+      const allAccountIds = accounts ? accounts.map((account) => account.id) : []
+      setAutoLendEnabledAccountIds(lendAssets ? allAccountIds : [])
+    },
+    [accounts, setAutoLendEnabledAccountIds],
+  )
 
-  const enableAutoLendAccountId = (accountId: string) => {
-    const setOfAccountIds = new Set(autoLendEnabledAccountIds)
+  const enableAutoLendAccountId = useCallback(
+    (accountId: string) => {
+      const setOfAccountIds = new Set(autoLendEnabledAccountIds)
 
-    if (!setOfAccountIds.has(accountId)) setOfAccountIds.add(accountId)
-    setAutoLendEnabledAccountIds(Array.from(setOfAccountIds))
-  }
+      if (!setOfAccountIds.has(accountId)) setOfAccountIds.add(accountId)
+      setAutoLendEnabledAccountIds(Array.from(setOfAccountIds))
+    },
+    [autoLendEnabledAccountIds, setAutoLendEnabledAccountIds],
+  )
 
   return {
     autoLendEnabledAccountIds,

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -967,6 +967,7 @@ interface BroadcastSlice {
   closeHlsStakingPosition: (options: { accountId: string; actions: Action[] }) => Promise<boolean>
   createAccount: (
     accountKind: import('types/generated/mars-rover-health-types/MarsRoverHealthTypes.types').AccountKind,
+    isAutoLendEnabled: boolean,
   ) => Promise<string | null>
   deleteAccount: (options: { accountId: string; lends: BNCoin[] }) => Promise<boolean>
   deposit: (options: { accountId: string; coins: BNCoin[]; lend: boolean }) => Promise<boolean>


### PR DESCRIPTION
This PR adds the accountId to the autloendAccountIds Array when creating a new account and activating the lend toggle on the fund account screen.