### PR TITLE
feature: update strategies and balances

### DIFF
--- a/src/components/portfolio/Account/Strategies.tsx
+++ b/src/components/portfolio/Account/Strategies.tsx
@@ -12,7 +12,7 @@ interface Props {
 function Content(props: Props) {
   const { account } = props
 
-  if (account.vaults.length === 0) {
+  if (account.vaults.length === 0 && account.stakedAstroLps.length === 0) {
     return null
   }
 

--- a/src/components/portfolio/Account/Summary.tsx
+++ b/src/components/portfolio/Account/Summary.tsx
@@ -6,13 +6,13 @@ import { FormattedNumber } from 'components/common/FormattedNumber'
 import useLendingMarketAssetsTableData from 'components/earn/lend/Table/useLendingMarketAssetsTableData'
 import Skeleton from 'components/portfolio/SummarySkeleton'
 import { MAX_AMOUNT_DECIMALS } from 'constants/math'
-import useAssets from 'hooks/assets/useAssets'
 import useAstroLpAprs from 'hooks/astroLp/useAstroLpAprs'
 import useHealthComputer from 'hooks/health-computer/useHealthComputer'
 import useHLSStakingAssets from 'hooks/hls/useHLSStakingAssets'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
 import { getAccountSummaryStats } from 'utils/accounts'
 import { DEFAULT_PORTFOLIO_STATS } from 'utils/constants'
+import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 
 interface Props {
   account: Account
@@ -27,7 +27,7 @@ function Content(props: Props) {
   const borrowAssets = useMemo(() => data?.allAssets || [], [data])
   const { allAssets: lendingAssets } = useLendingMarketAssetsTableData()
   const { data: hlsStrategies } = useHLSStakingAssets()
-  const { data: assets } = useAssets()
+  const assets = useWhitelistedAssets()
   const astroLpAprs = useAstroLpAprs()
 
   const stats = useMemo(() => {
@@ -75,7 +75,7 @@ function Content(props: Props) {
         title: (
           <FormattedNumber
             className='text-xl'
-            amount={isNaN(leverage.toNumber()) ? 1 : leverage.toNumber()}
+            amount={leverage.toNumber() || 1}
             options={{ suffix: 'x' }}
           />
         ),

--- a/src/components/portfolio/Overview/Summary.tsx
+++ b/src/components/portfolio/Overview/Summary.tsx
@@ -8,7 +8,7 @@ import useLendingMarketAssetsTableData from 'components/earn/lend/Table/useLendi
 import SummarySkeleton from 'components/portfolio/SummarySkeleton'
 import { MAX_AMOUNT_DECIMALS } from 'constants/math'
 import useAccounts from 'hooks/accounts/useAccounts'
-import useDepositEnabledAssets from 'hooks/assets/useDepositEnabledAssets'
+import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useAstroLpAprs from 'hooks/astroLp/useAstroLpAprs'
 import useHLSStakingAssets from 'hooks/hls/useHLSStakingAssets'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
@@ -25,7 +25,7 @@ export default function PortfolioSummary() {
   const { data: accounts } = useAccounts('default', urlAddress || walletAddress)
   const { data: hlsStrategies } = useHLSStakingAssets()
   const { data: vaultAprs } = useVaultAprs()
-  const assets = useDepositEnabledAssets()
+  const assets = useWhitelistedAssets()
   const astroLpAprs = useAstroLpAprs()
 
   const stats = useMemo(() => {
@@ -36,6 +36,9 @@ export default function PortfolioSummary() {
         combinedAccount.deposits = combinedAccount.deposits.concat(account.deposits)
         combinedAccount.lends = combinedAccount.lends.concat(account.lends)
         combinedAccount.vaults = combinedAccount.vaults.concat(account.vaults)
+        combinedAccount.stakedAstroLps = combinedAccount.stakedAstroLps.concat(
+          account.stakedAstroLps,
+        )
         return combinedAccount
       },
       {

--- a/src/utils/accounts.ts
+++ b/src/utils/accounts.ts
@@ -409,8 +409,14 @@ export function getAccountSummaryStats(
   astroLpAprs: Apr[],
   isHls?: boolean,
 ) {
-  const [deposits, lends, debts, vaults, stakedAstroLps] = getAccountPositionValues(account, assets)
-  const positionValue = deposits.plus(lends).plus(vaults).plus(stakedAstroLps)
+  const [deposits, lends, debts, vaults, perps, perpsVault, stakedAstroLps] =
+    getAccountPositionValues(account, assets)
+  const positionValue = deposits
+    .plus(lends)
+    .plus(vaults)
+    .plus(perps)
+    .plus(perpsVault)
+    .plus(stakedAstroLps)
   const apr = calculateAccountApr(
     account,
     borrowAssets,
@@ -422,7 +428,6 @@ export function getAccountSummaryStats(
     isHls,
   )
   const leverage = calculateAccountLeverage(account, assets)
-
   return {
     positionValue: BNCoin.fromDenomAndBigNumber(ORACLE_DENOM, positionValue),
     debts: BNCoin.fromDenomAndBigNumber(ORACLE_DENOM, debts),


### PR DESCRIPTION
Updated both the calculation of total balance and networth as well as include the atroport stakedLP like the vaults in osmosis
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a7995a39-fd56-4916-ac95-c18f838da09b">
