### PR TITLE
Fix APY <> APR conversion

### DIFF
--- a/src/api/campaign/getCampaignApys.ts
+++ b/src/api/campaign/getCampaignApys.ts
@@ -2,8 +2,9 @@ import { convertAprToApy } from 'utils/parsers'
 
 function processApyData(aprOrApy: number, isApr: boolean, isPercent: boolean): number {
   if (!isApr && isPercent) return aprOrApy
-  const apy = isApr ? convertAprToApy(aprOrApy, 365) : aprOrApy
-  return isPercent ? apy : apy * 100
+  const percentApr = isPercent ? aprOrApy : aprOrApy * 100
+  const apy = isApr ? convertAprToApy(percentApr, 365) : percentApr
+  return apy
 }
 
 export default async function getCampaignApys(

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -9,13 +9,12 @@ export function isNumber(value: unknown) {
   return typeof value === 'number'
 }
 
-export const convertAprToApy = (apr: number, numberOfCompoundingPeriods: number): number => {
-  return ((1 + apr / 100 / numberOfCompoundingPeriods) ** numberOfCompoundingPeriods - 1) * 100
+export const convertAprToApy = (apr: number, compoundFrequency: number): number => {
+  return ((1 + (apr * 0.01) / compoundFrequency) ** compoundFrequency - 1) * 100
 }
 
-export const convertApyToApr = (apy: number, numberOfCompoundingPeriods: number): number => {
-  const periodicRate = (1 + apy / 100) ** (1 / numberOfCompoundingPeriods) - 1
-  return periodicRate * numberOfCompoundingPeriods * 100
+export const convertApyToApr = (apy: number, compoundFrequency: number): number => {
+  return (((apy / 100 + 1) ** (1 / compoundFrequency) - 1) * compoundFrequency) / 0.01
 }
 
 export const combineBNCoins = (coins: BNCoin[]): BNCoin[] => {

--- a/src/utils/resolvers.ts
+++ b/src/utils/resolvers.ts
@@ -18,8 +18,8 @@ export function resolveMarketResponse(
     return {
       asset,
       apy: {
-        borrow: convertAprToApy(Number(marketResponse.borrow_rate), 365) * 100,
-        deposit: convertAprToApy(Number(marketResponse.liquidity_rate), 365) * 100,
+        borrow: convertAprToApy(Number(marketResponse.borrow_rate) * 100, 365),
+        deposit: convertAprToApy(Number(marketResponse.liquidity_rate) * 100, 365),
       },
       debt: marketResponse.debt ?? BN_ZERO,
       deposits: marketResponse.deposits ?? BN_ZERO,


### PR DESCRIPTION
There was a miscalculation taking place when converting APRs to APYs.

The former math was `APR converted to APY times 100` (if the value wasn't a percentage value)
The correct way is `APR times 100 converted to APY`. This leads to higher values after the calculation but is on-par with how DefiLlama converts APR to APY