### PR TITLE
Streamline APRs to APYs

### DIFF
--- a/src/components/Modals/AssetsSelect/Columns/Asset.tsx
+++ b/src/components/Modals/AssetsSelect/Columns/Asset.tsx
@@ -48,6 +48,7 @@ export default function Asset(props: Props) {
               type='apy'
               orientation='rtl'
               suffix
+              hasCampaignApy={asset.campaigns.find((c) => c.type === 'apy') !== undefined}
             />
           ) : (
             <Tooltip

--- a/src/components/account/AccountBalancesTable/Columns/Apy.tsx
+++ b/src/components/account/AccountBalancesTable/Columns/Apy.tsx
@@ -9,16 +9,16 @@ interface Props {
   markets: Market[]
   denom: string
   type: PositionType
+  hasCampaignApy?: boolean
 }
 
-export default function Apr(props: Props) {
-  const { markets, type, denom, apy } = props
+export default function Apy(props: Props) {
+  const { markets, type, denom, apy, hasCampaignApy } = props
 
   if (apy === undefined) return <Loading />
   if (apy === null) return <Text size='xs'>N/A</Text>
 
-  const isEnabled =
-    markets.find((market) => market.asset.denom === props.denom)?.borrowEnabled ?? false
+  const isEnabled = markets.find((market) => market.asset.denom === denom)?.borrowEnabled ?? false
 
   return (
     <AssetRate
@@ -27,6 +27,7 @@ export default function Apr(props: Props) {
       isEnabled={type !== 'lend' || isEnabled}
       type='apy'
       orientation='ltr'
+      hasCampaignApy={hasCampaignApy}
     />
   )
 }

--- a/src/components/account/AccountBalancesTable/Columns/useAccountBalancesColumns.tsx
+++ b/src/components/account/AccountBalancesTable/Columns/useAccountBalancesColumns.tsx
@@ -121,6 +121,7 @@ export default function useAccountBalancesColumns(
           markets={markets}
           denom={row.original.denom}
           type={row.original.type}
+          hasCampaignApy={row.original.campaigns.find((c) => c.type === 'apy') !== undefined}
         />
       ),
     }),

--- a/src/components/account/AccountBalancesTable/functions.ts
+++ b/src/components/account/AccountBalancesTable/functions.ts
@@ -21,6 +21,7 @@ export function getAssetAccountBalanceRow(
     amount,
     apy,
     amountChange,
+    campaigns: asset.campaigns,
   }
 }
 

--- a/src/components/account/AccountComposition.tsx
+++ b/src/components/account/AccountComposition.tsx
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js'
 import classNames from 'classnames'
 import { useMemo } from 'react'
 
+import useAccountPerpData from 'components/account/AccountPerpPositionTable/useAccountPerpData'
 import useBorrowMarketAssetsTableData from 'components/borrow/Table/useBorrowMarketAssetsTableData'
 import DisplayCurrency from 'components/common/DisplayCurrency'
 import { FormattedNumber } from 'components/common/FormattedNumber'
@@ -12,18 +13,16 @@ import { BN_ZERO, MAX_AMOUNT_DECIMALS } from 'constants/math'
 import { ORACLE_DENOM } from 'constants/oracle'
 import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useAstroLpAprs from 'hooks/astroLp/useAstroLpAprs'
-import useHlsStakingAssets from 'hooks/hls/useHlsStakingAssets'
+import useChainConfig from 'hooks/chain/useChainConfig'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
 import useStore from 'store'
 import { BNCoin } from 'types/classes/BNCoin'
 import {
-  calculateAccountApr,
+  calculateAccountApy,
   getAccountDebtValue,
   getAccountTotalValue,
   getAccountUnrealizedPnlValue,
 } from 'utils/accounts'
-import useAccountPerpData from 'components/account/AccountPerpPositionTable/useAccountPerpData'
-import useChainConfig from 'hooks/chain/useChainConfig'
 
 interface Props {
   account: Account
@@ -42,7 +41,6 @@ export default function AccountComposition(props: Props) {
   const updatedAccount = useStore((s) => s.updatedAccount)
   const { account } = props
   const hasChanged = !!updatedAccount
-  const { data: hlsStrategies } = useHlsStakingAssets()
   const { data: vaultAprs } = useVaultAprs()
   const accountPerpData = useAccountPerpData({
     account,
@@ -80,41 +78,31 @@ export default function AccountComposition(props: Props) {
     [updatedAccount, account, assets],
   )
 
-  const apr = useMemo(
+  const apy = useMemo(
     () =>
-      calculateAccountApr(
+      calculateAccountApy(
         account,
         borrowAssetsData,
         lendingAssetsData,
-        hlsStrategies,
         assets,
         vaultAprs,
         astroLpAprs,
       ),
-    [account, assets, borrowAssetsData, hlsStrategies, lendingAssetsData, vaultAprs, astroLpAprs],
+    [account, assets, borrowAssetsData, lendingAssetsData, vaultAprs, astroLpAprs],
   )
-  const updatedApr = useMemo(
+  const updatedApy = useMemo(
     () =>
       updatedAccount
-        ? calculateAccountApr(
+        ? calculateAccountApy(
             updatedAccount,
             borrowAssetsData,
             lendingAssetsData,
-            hlsStrategies,
             assets,
             vaultAprs,
             astroLpAprs,
           )
         : BN_ZERO,
-    [
-      updatedAccount,
-      borrowAssetsData,
-      lendingAssetsData,
-      hlsStrategies,
-      assets,
-      vaultAprs,
-      astroLpAprs,
-    ],
+    [updatedAccount, borrowAssetsData, lendingAssetsData, assets, vaultAprs, astroLpAprs],
   )
 
   return (
@@ -141,9 +129,9 @@ export default function AccountComposition(props: Props) {
         />
       )}
       <Item
-        title='APR'
-        current={apr}
-        change={hasChanged ? updatedApr : apr}
+        title='APY'
+        current={apy}
+        change={hasChanged ? updatedApy : apy}
         className='pb-3'
         isPercentage
       />

--- a/src/components/account/AccountDetails/Skeleton.tsx
+++ b/src/components/account/AccountDetails/Skeleton.tsx
@@ -37,7 +37,7 @@ export default function Skeleton(props: Props) {
         </div>
         <div className='flex flex-wrap justify-center w-full py-4 border-t border-white/20'>
           <Text size='2xs' className='mb-0.5 w-full text-center text-white/50'>
-            APR
+            APY
           </Text>
           <Loading className='w-10 h-3 mt-1' />
         </div>

--- a/src/components/account/AccountDetails/index.tsx
+++ b/src/components/account/AccountDetails/index.tsx
@@ -25,13 +25,12 @@ import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useAstroLpAprs from 'hooks/astroLp/useAstroLpAprs'
 import useChainConfig from 'hooks/chain/useChainConfig'
 import useHealthComputer from 'hooks/health-computer/useHealthComputer'
-import useHlsStakingAssets from 'hooks/hls/useHlsStakingAssets'
 import useLocalStorage from 'hooks/localStorage/useLocalStorage'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
 import useStore from 'store'
 import { BNCoin } from 'types/classes/BNCoin'
 import {
-  calculateAccountApr,
+  calculateAccountApy,
   calculateAccountBalanceValue,
   calculateAccountLeverage,
 } from 'utils/accounts'
@@ -68,7 +67,6 @@ function AccountDetails(props: Props) {
   const chainConfig = useChainConfig()
   const { account } = props
   const location = useLocation()
-  const { data: hlsStrategies } = useHlsStakingAssets()
   const { data: vaultAprs } = useVaultAprs()
   const astroLpAprs = useAstroLpAprs()
   const [reduceMotion] = useLocalStorage<boolean>(
@@ -113,13 +111,12 @@ function AccountDetails(props: Props) {
     () => [...lendingAvailableAssets, ...accountLentAssets],
     [lendingAvailableAssets, accountLentAssets],
   )
-  const apr = useMemo(
+  const apy = useMemo(
     () =>
-      calculateAccountApr(
+      calculateAccountApy(
         updatedAccount ?? account,
         borrowAssetsData,
         lendingAssetsData,
-        hlsStrategies,
         whitelistedAssets,
         vaultAprs,
         astroLpAprs,
@@ -128,7 +125,6 @@ function AccountDetails(props: Props) {
       account,
       whitelistedAssets,
       borrowAssetsData,
-      hlsStrategies,
       lendingAssetsData,
       updatedAccount,
       vaultAprs,
@@ -211,11 +207,11 @@ function AccountDetails(props: Props) {
             </div>
             <div className='w-full py-4 border-t border-white/20'>
               <Text size='2xs' className='mb-0.5 w-full text-center text-white/50'>
-                APR
+                APY
               </Text>
               <FormattedNumber
                 className={'w-full text-center text-2xs'}
-                amount={apr.toNumber()}
+                amount={apy.toNumber()}
                 options={{ maxDecimals: 2, minDecimals: 2, suffix: '%' }}
                 animate
               />

--- a/src/components/account/AccountList/AccountStats.tsx
+++ b/src/components/account/AccountList/AccountStats.tsx
@@ -11,10 +11,9 @@ import useAccount from 'hooks/accounts/useAccount'
 import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useAstroLpAprs from 'hooks/astroLp/useAstroLpAprs'
 import useHealthComputer from 'hooks/health-computer/useHealthComputer'
-import useHlsStakingAssets from 'hooks/hls/useHlsStakingAssets'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
 import useStore from 'store'
-import { calculateAccountApr, calculateAccountBalanceValue } from 'utils/accounts'
+import { calculateAccountApy, calculateAccountBalanceValue } from 'utils/accounts'
 import { mergeBNCoinArrays } from 'utils/helpers'
 
 interface Props {
@@ -27,7 +26,6 @@ export default function AccountStats(props: Props) {
   const { accountId, isActive, setShowMenu } = props
   const assets = useWhitelistedAssets()
   const { data: account } = useAccount(accountId)
-  const { data: hlsStrategies } = useHlsStakingAssets()
   const { data: vaultAprs } = useVaultAprs()
   const astroLpAprs = useAstroLpAprs()
   const positionBalance = useMemo(
@@ -47,16 +45,15 @@ export default function AccountStats(props: Props) {
     () =>
       !account
         ? null
-        : calculateAccountApr(
+        : calculateAccountApy(
             account,
             borrowAssetsData,
             lendingAssetsData,
-            hlsStrategies,
             assets,
             vaultAprs,
             astroLpAprs,
           ),
-    [account, assets, borrowAssetsData, hlsStrategies, lendingAssetsData, vaultAprs, astroLpAprs],
+    [account, assets, borrowAssetsData, lendingAssetsData, vaultAprs, astroLpAprs],
   )
 
   const deleteAccountHandler = useCallback(() => {

--- a/src/components/account/AccountSummary/index.tsx
+++ b/src/components/account/AccountSummary/index.tsx
@@ -16,11 +16,10 @@ import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useAstroLpAprs from 'hooks/astroLp/useAstroLpAprs'
 import useChainConfig from 'hooks/chain/useChainConfig'
 import useHealthComputer from 'hooks/health-computer/useHealthComputer'
-import useHlsStakingAssets from 'hooks/hls/useHlsStakingAssets'
 import useLocalStorage from 'hooks/localStorage/useLocalStorage'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
 import useStore from 'store'
-import { calculateAccountApr, calculateAccountLeverage } from 'utils/accounts'
+import { calculateAccountApy, calculateAccountLeverage } from 'utils/accounts'
 
 interface Props {
   account: Account
@@ -29,7 +28,6 @@ interface Props {
 
 export default function AccountSummary(props: Props) {
   const { account, isInModal } = props
-  const isHls = account.kind === 'high_levered_strategy'
   const chainConfig = useChainConfig()
   const storageKey = isInModal
     ? `${chainConfig.id}/${LocalStorageKeys.ACCOUNT_SUMMARY_IN_MODAL_TABS_EXPANDED}`
@@ -50,7 +48,6 @@ export default function AccountSummary(props: Props) {
   const borrowAssetsData = useMemo(() => data?.allAssets || [], [data])
   const { availableAssets: lendingAvailableAssets, accountLentAssets } =
     useLendingMarketAssetsTableData()
-  const { data: hlsStrategies } = useHlsStakingAssets()
   const lendingAssetsData = useMemo(
     () => [...lendingAvailableAssets, ...accountLentAssets],
     [lendingAvailableAssets, accountLentAssets],
@@ -88,11 +85,10 @@ export default function AccountSummary(props: Props) {
 
   const apr = useMemo(
     () =>
-      calculateAccountApr(
+      calculateAccountApy(
         updatedAccount ?? account,
         borrowAssetsData,
         lendingAssetsData,
-        hlsStrategies,
         [...whitelistedAssets, ...perpsAssets],
         vaultAprs,
         astroLpAprs,
@@ -102,7 +98,6 @@ export default function AccountSummary(props: Props) {
       updatedAccount,
       borrowAssetsData,
       lendingAssetsData,
-      hlsStrategies,
       whitelistedAssets,
       perpsAssets,
       vaultAprs,

--- a/src/components/common/Select/Option.tsx
+++ b/src/components/common/Select/Option.tsx
@@ -87,6 +87,7 @@ export default function Option(props: Props) {
           type='apy'
           orientation='rtl'
           suffix
+          hasCampaignApy={asset.campaigns.find((c) => c.type === 'apy') !== undefined}
         />
         <DisplayCurrency
           className='col-span-2 text-sm text-right text-white/50'

--- a/src/components/common/assets/AssetRate.tsx
+++ b/src/components/common/assets/AssetRate.tsx
@@ -12,16 +12,22 @@ interface Props {
   orientation: 'ltr' | 'rtl'
   className?: string
   suffix?: boolean
+  hasCampaignApy?: boolean
 }
 
 interface TooltipProps {
   orientation: Props['orientation']
+  hasCampaignApy?: boolean
 }
 
 function RateTooltip(props: TooltipProps) {
   return (
     <Tooltip
-      content='This asset cannot be borrowed, and thus does not currently generate yield when lending.'
+      content={
+        props.hasCampaignApy
+          ? 'This asset cannot be borrowed, but generates its underlying staking APY.'
+          : 'This asset cannot be borrowed, and thus does not currently generate yield when lending.'
+      }
       type='info'
       className={props.orientation === 'ltr' ? 'mr-1' : 'ml-1'}
     >
@@ -31,14 +37,15 @@ function RateTooltip(props: TooltipProps) {
 }
 
 export default function AssetRate(props: Props) {
-  const { rate, isEnabled, type, orientation, className } = props
+  const { rate, isEnabled, type, orientation, className, hasCampaignApy } = props
   const suffix = type === 'apy' ? 'APY' : 'APR'
 
   if (!isEnabled)
     return (
       <Text tag='div' className={classNames('flex items-center', className)}>
-        {orientation === 'ltr' && <RateTooltip orientation='ltr' />}N/A
-        {orientation === 'rtl' && <RateTooltip orientation='rtl' />}
+        {orientation === 'ltr' && <RateTooltip orientation='ltr' hasCampaignApy={hasCampaignApy} />}
+        N/A
+        {orientation === 'rtl' && <RateTooltip orientation='rtl' hasCampaignApy={hasCampaignApy} />}
       </Text>
     )
 

--- a/src/components/earn/lend/Table/Columns/Apy.tsx
+++ b/src/components/earn/lend/Table/Columns/Apy.tsx
@@ -12,6 +12,7 @@ interface Props {
   apy: number
   borrowEnabled: boolean
   isLoading: boolean
+  hasCampaignApy?: boolean
 }
 export default function Apr(props: Props) {
   if (props.isLoading) return <Loading />
@@ -23,6 +24,7 @@ export default function Apr(props: Props) {
       className='justify-end text-xs'
       type='apy'
       orientation='ltr'
+      hasCampaignApy={props.hasCampaignApy}
     />
   )
 }

--- a/src/components/earn/lend/Table/Columns/useAvailableColumns.tsx
+++ b/src/components/earn/lend/Table/Columns/useAvailableColumns.tsx
@@ -34,6 +34,9 @@ export default function useAvailableColumns(props: Props) {
             isLoading={props.isLoading}
             borrowEnabled={row.original.borrowEnabled}
             apy={row.original.apy.deposit}
+            hasCampaignApy={
+              row.original.asset.campaigns.find((c) => c.type === 'apy') !== undefined
+            }
           />
         ),
       },

--- a/src/components/earn/lend/Table/Columns/useDepositedColumns.tsx
+++ b/src/components/earn/lend/Table/Columns/useDepositedColumns.tsx
@@ -58,6 +58,9 @@ export default function useDepositedColumns(props: Props) {
             isLoading={props.isLoading}
             borrowEnabled={row.original.borrowEnabled}
             apy={row.original.apy.deposit}
+            hasCampaignApy={
+              row.original.asset.campaigns.find((c) => c.type === 'apy') !== undefined
+            }
           />
         ),
       },

--- a/src/components/portfolio/Account/Summary.tsx
+++ b/src/components/portfolio/Account/Summary.tsx
@@ -9,7 +9,6 @@ import { MAX_AMOUNT_DECIMALS } from 'constants/math'
 import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useAstroLpAprs from 'hooks/astroLp/useAstroLpAprs'
 import useHealthComputer from 'hooks/health-computer/useHealthComputer'
-import useHlsStakingAssets from 'hooks/hls/useHlsStakingAssets'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
 import { getAccountSummaryStats } from 'utils/accounts'
 import { DEFAULT_PORTFOLIO_STATS } from 'utils/constants'
@@ -26,18 +25,16 @@ function Content(props: Props) {
   const data = useBorrowMarketAssetsTableData()
   const borrowAssets = useMemo(() => data?.allAssets || [], [data])
   const { allAssets: lendingAssets } = useLendingMarketAssetsTableData()
-  const { data: hlsStrategies } = useHlsStakingAssets()
   const assets = useWhitelistedAssets()
   const astroLpAprs = useAstroLpAprs()
 
   const stats = useMemo(() => {
     if (!account || !borrowAssets.length || !lendingAssets.length) return DEFAULT_PORTFOLIO_STATS
 
-    const { positionValue, debts, netWorth, apr, leverage } = getAccountSummaryStats(
+    const { positionValue, debts, netWorth, apy, leverage } = getAccountSummaryStats(
       account,
       borrowAssets,
       lendingAssets,
-      hlsStrategies,
       assets,
       vaultAprs,
       astroLpAprs,
@@ -60,10 +57,10 @@ function Content(props: Props) {
         title: (
           <FormattedNumber
             className='text-xl'
-            amount={apr.toNumber()}
+            amount={apy.toNumber()}
             options={{
               suffix: '%',
-              maxDecimals: apr.abs().isLessThan(0.1) ? MAX_AMOUNT_DECIMALS : 2,
+              maxDecimals: apy.abs().isLessThan(0.1) ? MAX_AMOUNT_DECIMALS : 2,
               minDecimals: 2,
             }}
           />
@@ -81,16 +78,7 @@ function Content(props: Props) {
         sub: props.v1 ? 'Total Leverage' : DEFAULT_PORTFOLIO_STATS[4].sub,
       },
     ]
-  }, [
-    account,
-    assets,
-    borrowAssets,
-    hlsStrategies,
-    lendingAssets,
-    vaultAprs,
-    props.v1,
-    astroLpAprs,
-  ])
+  }, [account, assets, borrowAssets, lendingAssets, vaultAprs, props.v1, astroLpAprs])
 
   return (
     <Skeleton

--- a/src/components/portfolio/Card/index.tsx
+++ b/src/components/portfolio/Card/index.tsx
@@ -15,7 +15,6 @@ import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useAstroLpAprs from 'hooks/astroLp/useAstroLpAprs'
 import useChainConfig from 'hooks/chain/useChainConfig'
 import useHealthComputer from 'hooks/health-computer/useHealthComputer'
-import useHlsStakingAssets from 'hooks/hls/useHlsStakingAssets'
 import useLocalStorage from 'hooks/localStorage/useLocalStorage'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
 import { getAccountSummaryStats } from 'utils/accounts'
@@ -34,7 +33,6 @@ export default function PortfolioCard(props: Props) {
   const currentAccountId = useAccountId()
   const { allAssets: lendingAssets } = useLendingMarketAssetsTableData()
   const data = useBorrowMarketAssetsTableData()
-  const { data: hlsStrategies } = useHlsStakingAssets()
   const { data: vaultAprs } = useVaultAprs()
   const [searchParams] = useSearchParams()
   const assets = useWhitelistedAssets()
@@ -49,15 +47,14 @@ export default function PortfolioCard(props: Props) {
       return [
         { title: <Loading />, sub: 'Net worth' },
         { title: <Loading />, sub: 'Leverage' },
-        { title: <Loading />, sub: 'APR' },
+        { title: <Loading />, sub: 'APY' },
       ]
     }
 
-    const { netWorth, apr, leverage } = getAccountSummaryStats(
+    const { netWorth, apy, leverage } = getAccountSummaryStats(
       account as Account,
       borrowAssets,
       lendingAssets,
-      hlsStrategies,
       assets,
       vaultAprs,
       astroLpAprs,
@@ -73,11 +70,11 @@ export default function PortfolioCard(props: Props) {
         sub: 'Leverage',
       },
       {
-        title: <FormattedNumber amount={apr.toNumber()} options={{ suffix: '%' }} />,
-        sub: 'APR',
+        title: <FormattedNumber amount={apy.toNumber()} options={{ suffix: '%' }} />,
+        sub: 'APY',
       },
     ]
-  }, [account, assets, borrowAssets, hlsStrategies, lendingAssets, vaultAprs, astroLpAprs])
+  }, [account, assets, borrowAssets, lendingAssets, vaultAprs, astroLpAprs])
 
   if (!account) {
     return (

--- a/src/components/portfolio/Overview/Summary.tsx
+++ b/src/components/portfolio/Overview/Summary.tsx
@@ -10,11 +10,11 @@ import { MAX_AMOUNT_DECIMALS } from 'constants/math'
 import useAccounts from 'hooks/accounts/useAccounts'
 import useWhitelistedAssets from 'hooks/assets/useWhitelistedAssets'
 import useAstroLpAprs from 'hooks/astroLp/useAstroLpAprs'
-import useHlsStakingAssets from 'hooks/hls/useHlsStakingAssets'
 import useVaultAprs from 'hooks/vaults/useVaultAprs'
 import useStore from 'store'
 import { getAccountSummaryStats } from 'utils/accounts'
 import { DEFAULT_PORTFOLIO_STATS } from 'utils/constants'
+import { mergeBNCoinArrays } from 'utils/helpers'
 
 export default function PortfolioSummary() {
   const { address: urlAddress } = useParams()
@@ -24,7 +24,6 @@ export default function PortfolioSummary() {
   const { allAssets: lendingAssets } = useLendingMarketAssetsTableData()
   const { data: defaultAccounts } = useAccounts('default', urlAddress || walletAddress)
   const { data: hlsAccounts } = useAccounts('high_levered_strategy', urlAddress || walletAddress)
-  const { data: hlsStrategies } = useHlsStakingAssets()
   const { data: vaultAprs } = useVaultAprs()
   const assets = useWhitelistedAssets()
   const astroLpAprs = useAstroLpAprs()
@@ -37,17 +36,18 @@ export default function PortfolioSummary() {
     if (!allAccounts?.length) return
     const combinedAccount = allAccounts.reduce(
       (combinedAccount, account) => {
-        combinedAccount.debts = combinedAccount.debts.concat(account.debts)
-        combinedAccount.deposits = combinedAccount.deposits.concat(account.deposits)
-        combinedAccount.lends = combinedAccount.lends.concat(account.lends)
+        combinedAccount.debts = mergeBNCoinArrays(combinedAccount.debts, account.debts)
+        combinedAccount.deposits = mergeBNCoinArrays(combinedAccount.deposits, account.deposits)
+        combinedAccount.lends = mergeBNCoinArrays(combinedAccount.lends, account.lends)
         combinedAccount.vaults = combinedAccount.vaults.concat(account.vaults)
-        combinedAccount.stakedAstroLps = combinedAccount.stakedAstroLps.concat(
+        combinedAccount.stakedAstroLps = mergeBNCoinArrays(
+          combinedAccount.stakedAstroLps,
           account.stakedAstroLps,
         )
         return combinedAccount
       },
       {
-        id: '1',
+        id: 'combined',
         deposits: [],
         lends: [],
         debts: [],
@@ -59,11 +59,10 @@ export default function PortfolioSummary() {
       } as Account,
     )
 
-    const { positionValue, debts, netWorth, apr, leverage } = getAccountSummaryStats(
+    const { positionValue, debts, netWorth, apy, leverage } = getAccountSummaryStats(
       combinedAccount,
       borrowAssets,
       lendingAssets,
-      hlsStrategies,
       assets,
       vaultAprs,
       astroLpAprs,
@@ -86,15 +85,15 @@ export default function PortfolioSummary() {
         title: (
           <FormattedNumber
             className='text-xl'
-            amount={apr.toNumber()}
+            amount={apy.toNumber()}
             options={{
               suffix: '%',
-              maxDecimals: apr.abs().isLessThan(0.1) ? MAX_AMOUNT_DECIMALS : 2,
+              maxDecimals: apy.abs().isLessThan(0.1) ? MAX_AMOUNT_DECIMALS : 2,
               minDecimals: 2,
             }}
           />
         ),
-        sub: 'Combined APR',
+        sub: 'Combined APY',
       },
       {
         title: (
@@ -107,7 +106,7 @@ export default function PortfolioSummary() {
         sub: 'Combined leverage',
       },
     ]
-  }, [allAccounts, assets, borrowAssets, hlsStrategies, lendingAssets, vaultAprs, astroLpAprs])
+  }, [allAccounts, assets, borrowAssets, lendingAssets, vaultAprs, astroLpAprs])
 
   if (!walletAddress && !urlAddress) return null
 

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -56,6 +56,7 @@ interface AccountBalanceRow {
   type: PositionType
   value: string
   amountChange: BigNumber
+  campaigns: AssetCampaign[]
 }
 
 interface AccountStrategyRow {

--- a/src/utils/accounts.ts
+++ b/src/utils/accounts.ts
@@ -10,7 +10,7 @@ import { Positions } from 'types/generated/mars-rover-health-computer/MarsRoverH
 import { byDenom } from 'utils/array'
 import { getCoinValue } from 'utils/formatters'
 import { BN } from 'utils/helpers'
-import { convertApyToApr } from 'utils/parsers'
+import { convertAprToApy } from 'utils/parsers'
 
 export const calculateAccountBalanceValue = (
   account: Account | AccountChange,
@@ -100,11 +100,10 @@ export const calculateAccountValue = (
   )
 }
 
-export const calculateAccountApr = (
+export const calculateAccountApy = (
   account: Account,
   borrowAssetsData: BorrowMarketTableData[],
   lendingAssetsData: LendingMarketTableData[],
-  hlsStrategies: HlsStrategy[],
   assets: Asset[],
   vaultAprs: Apr[],
   astroLpAprs: Apr[],
@@ -122,7 +121,7 @@ export const calculateAccountApr = (
     .plus(vaultsValue)
     .plus(perpsValue)
     .plus(stakedAstroLpsValue)
-    .plus(debtsValue.abs())
+    .minus(debtsValue.abs())
 
   if (totalDenominatorValue.isLessThanOrEqualTo(0)) return BN_ZERO
   const { vaults, lends, debts, deposits, stakedAstroLps } = account
@@ -133,23 +132,20 @@ export const calculateAccountApr = (
   let totalDebtInterestValue = BN_ZERO
   let totalAstroStakedLpsValue = BN_ZERO
 
-  if (isHls) {
-    deposits?.forEach((deposit) => {
-      const asset = assets.find(byDenom(deposit.denom))
-      if (!asset) return BN_ZERO
-      const price = asset.price?.amount ?? BN_ZERO
-      const amount = deposit.amount.shiftedBy(-asset.decimals)
-      const apy =
-        hlsStrategies.find((strategy) => strategy.denoms.deposit === deposit.denom)?.apy || 0
-
-      const positionInterest = amount
-        .multipliedBy(price)
-        .multipliedBy(convertApyToApr(apy, 365))
-        .dividedBy(100)
-
-      totalDepositsInterestValue = totalDepositsInterestValue.plus(positionInterest)
+  deposits?.forEach((deposit) => {
+    const asset = assets.find(byDenom(deposit.denom))
+    if (!asset) return BN_ZERO
+    const price = asset.price?.amount ?? BN_ZERO
+    const amount = deposit.amount.shiftedBy(-asset.decimals)
+    let apy = 0
+    asset.campaigns.forEach((campaign) => {
+      if (campaign.type === 'apy') apy = apy + (campaign.apy ?? 0)
     })
-  }
+
+    const positionInterest = amount.multipliedBy(price).multipliedBy(apy).dividedBy(100)
+
+    totalDepositsInterestValue = totalDepositsInterestValue.plus(positionInterest)
+  })
 
   lends?.forEach((lend) => {
     const asset = assets.find(byDenom(lend.denom))
@@ -161,19 +157,17 @@ export const calculateAccountApr = (
 
     if (!apy) return
 
-    const positionInterest = amount
-      .multipliedBy(price)
-      .multipliedBy(convertApyToApr(apy, 365))
-      .dividedBy(100)
+    const positionInterest = amount.multipliedBy(price).multipliedBy(apy).dividedBy(100)
 
     totalLendsInterestValue = totalLendsInterestValue.plus(positionInterest)
   })
 
   vaults?.forEach((vault) => {
     const apr = vaultAprs.find((vaultApr) => vaultApr.address === vault.address)?.apr
-    if (!apr) return
+    const apy = convertAprToApy(apr ?? 0, 365)
+    if (!apy) return
     const lockedValue = vault.values.primary.plus(vault.values.secondary)
-    const positionInterest = lockedValue.multipliedBy(apr).dividedBy(100)
+    const positionInterest = lockedValue.multipliedBy(apy).dividedBy(100)
 
     totalVaultsInterestValue = totalVaultsInterestValue.plus(positionInterest)
   })
@@ -188,10 +182,7 @@ export const calculateAccountApr = (
 
     if (!apy) return
 
-    const positionInterest = amount
-      .multipliedBy(price)
-      .multipliedBy(convertApyToApr(apy, 365))
-      .dividedBy(100)
+    const positionInterest = amount.multipliedBy(price).multipliedBy(apy).dividedBy(100)
 
     totalDebtInterestValue = totalDebtInterestValue.plus(positionInterest)
   })
@@ -200,8 +191,9 @@ export const calculateAccountApr = (
     const farm = astroLpAprs.find((farmApr) => farmApr.address === stakedAstroLp.denom)
     if (!farm) return
     const farmApr = farm.apr ?? 0
+    const apy = convertAprToApy(farmApr, 365)
     const farmValue = getCoinValue(stakedAstroLp, assets)
-    const positionInterest = farmValue.multipliedBy(farmApr).dividedBy(100)
+    const positionInterest = farmValue.multipliedBy(apy).dividedBy(100)
 
     totalAstroStakedLpsValue = totalAstroStakedLpsValue.plus(positionInterest)
   })
@@ -441,7 +433,6 @@ export function getAccountSummaryStats(
   account: Account,
   borrowAssets: BorrowMarketTableData[],
   lendingAssets: LendingMarketTableData[],
-  hlsStrategies: HlsStrategy[],
   assets: Asset[],
   vaultAprs: Apr[],
   astroLpAprs: Apr[],
@@ -454,11 +445,10 @@ export function getAccountSummaryStats(
     .plus(perps)
     .plus(perpsVault)
     .plus(stakedAstroLps)
-  const apr = calculateAccountApr(
+  const apy = calculateAccountApy(
     account,
     borrowAssets,
     lendingAssets,
-    hlsStrategies,
     assets,
     vaultAprs,
     astroLpAprs,
@@ -468,7 +458,7 @@ export function getAccountSummaryStats(
     positionValue: BNCoin.fromDenomAndBigNumber(ORACLE_DENOM, positionValue),
     debts: BNCoin.fromDenomAndBigNumber(ORACLE_DENOM, debts),
     netWorth: BNCoin.fromDenomAndBigNumber(ORACLE_DENOM, positionValue.minus(debts)),
-    apr,
+    apy,
     leverage,
   }
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -17,7 +17,7 @@ export const DEFAULT_PORTFOLIO_STATS = [
   { title: null, sub: 'Total Balance' },
   { title: null, sub: 'Total Debt' },
   { title: null, sub: 'Net Worth' },
-  { title: null, sub: 'APR' },
+  { title: null, sub: 'APY' },
   { title: null, sub: 'Account Leverage' },
 ]
 


### PR DESCRIPTION
This PR contains the following changes:

- APR got converted to APY on the account level
- underlying staking rewards are now included in the Account total APY
- the math to calculate total account APY got adjusted
- a tooltip for LSTs was added