### PR TITLE
Ignore Debt Amount for Deposit Cap checks on Auto Repay

### DIFF
--- a/src/components/trade/TradeModule/SwapForm/index.tsx
+++ b/src/components/trade/TradeModule/SwapForm/index.tsx
@@ -90,13 +90,17 @@ export default function SwapForm(props: Props) {
 
     if (!outputMarketAsset || !outputMarketAsset.cap) return []
 
-    const depositCapLeft = getCapLeftWithBuffer(outputMarketAsset.cap)
+    let depositCapLeft = getCapLeftWithBuffer(outputMarketAsset.cap)
+    if (isAutoRepayChecked && account) {
+      const debtAmount = account.debts.find(byDenom(outputAsset.denom))?.amount ?? BN_ZERO
+      depositCapLeft = depositCapLeft.plus(debtAmount)
+    }
     if (outputAssetAmount.isGreaterThan(depositCapLeft)) {
       return [BNCoin.fromDenomAndBigNumber(outputAsset.denom, depositCapLeft)]
     }
 
     return []
-  }, [markets, outputAsset.denom, outputAssetAmount])
+  }, [account, isAutoRepayChecked, markets, outputAsset.denom, outputAssetAmount])
 
   const handleRangeInputChange = useCallback(
     (value: number) => {


### PR DESCRIPTION
This PR adds the debt amount of the output asset to the deposit cap to prevent users from being blocked to auto-repay debt on an asset that reached its deposit cap.