### PR TITLE
fix: preview and perps summary modal

### DIFF
--- a/src/components/perps/Module/ConfirmationSummary.tsx
+++ b/src/components/perps/Module/ConfirmationSummary.tsx
@@ -52,7 +52,9 @@ export default function ConfirmationSummary(props: Props) {
     const previousAmount = BN(positionSize as string)
     const newAmount = previousAmount.plus(amount)
     const isNewPosition = previousAmount.isZero()
-    const tradeDirection = newAmount.isPositive() ? 'long' : 'short'
+    const previousTradeDirection = previousAmount.isPositive() ? 'long' : 'short'
+    const newDirection = newAmount.isPositive() ? 'long' : 'short'
+    const tradeDirection = newAmount.isZero() ? previousTradeDirection : newDirection
 
     return [newAmount, tradeDirection, isNewPosition, previousAmount]
   }, [amount, isLoading, updatePerpsPosition])
@@ -104,9 +106,9 @@ export default function ConfirmationSummary(props: Props) {
   let action = 'Open new position'
   if (!isNewPosition) action = 'Update existing position'
   if (newAmount.isZero()) action = 'Close position'
-  if (previousAmount.isPositive() && newAmount.isNegative())
+  if (previousAmount.isPositive() && !previousAmount.isZero() && newAmount.isNegative())
     action = 'Flip position from long to short'
-  if (previousAmount.isNegative() && newAmount.isPositive())
+  if (previousAmount.isNegative() && newAmount.isPositive() && !newAmount.isZero())
     action = 'Flip position from short to long'
 
   let feeLabel = 'Fees'

--- a/src/components/perps/Module/PerpsModule.tsx
+++ b/src/components/perps/Module/PerpsModule.tsx
@@ -5,13 +5,15 @@ import AssetAmountInput from 'components/common/AssetAmountInput'
 import { Callout, CalloutType } from 'components/common/Callout'
 import Card from 'components/common/Card'
 import Divider from 'components/common/Divider'
+import LeverageSlider from 'components/common/LeverageSlider'
 import OrderTypeSelector from 'components/common/OrderTypeSelector'
+import SwitchWithLabel from 'components/common/Switch/SwitchWithLabel'
 import Text from 'components/common/Text'
 import { TradeDirectionSelector } from 'components/common/TradeDirectionSelector'
+import KeeperFee from 'components/perps/Module/KeeperFee'
 import { LeverageButtons } from 'components/perps/Module/LeverageButtons'
 import { Or } from 'components/perps/Module/Or'
 import PerpsSummary from 'components/perps/Module/Summary'
-import KeeperFee from 'components/perps/Module/KeeperFee'
 import { DEFAULT_LIMIT_PRICE_INFO, PERPS_ORDER_TYPE_TABS } from 'components/perps/Module/constants'
 import usePerpsModule from 'components/perps/Module/usePerpsModule'
 import AssetSelectorPerps from 'components/trade/TradeModule/AssetSelector/AssetSelectorPerps'
@@ -26,10 +28,8 @@ import useAutoLend from 'hooks/wallet/useAutoLend'
 import useStore from 'store'
 import { OrderType } from 'types/enums'
 import { byDenom } from 'utils/array'
-import { capitalizeFirstLetter } from 'utils/helpers'
 import getPerpsPosition from 'utils/getPerpsPosition'
-import LeverageSlider from 'components/common/LeverageSlider'
-import SwitchWithLabel from 'components/common/Switch/SwitchWithLabel'
+import { capitalizeFirstLetter } from 'utils/helpers'
 
 export function PerpsModule() {
   const [tradeDirection, setTradeDirection] = useState<TradeDirection>('long')
@@ -183,16 +183,20 @@ export function PerpsModule() {
 
   useEffect(() => {
     if (!tradingFee || !perpsVault || isLimitOrder || perpsVaultModal) return
+    const newAmount = currentPerpPosition?.amount.plus(amount) ?? amount
+    const previousTradeDirection = currentPerpPosition?.amount.isLessThan(0) ? 'short' : 'long'
+    const newTradeDirection = newAmount.isLessThan(0) ? 'short' : 'long'
+    const tradeDirection = newAmount.isZero() ? previousTradeDirection : newTradeDirection
 
     const newPosition = getPerpsPosition(
       perpsVault.denom,
       perpsAsset,
-      amount.plus(amount),
+      newAmount,
       tradeDirection,
       tradingFee,
       currentPerpPosition,
     )
-    if (newPosition) simulatePerps(newPosition, isAutoLendEnabledForCurrentAccount)
+    simulatePerps(newPosition, isAutoLendEnabledForCurrentAccount)
   }, [
     amount,
     currentPerpPosition,

--- a/src/utils/getPerpsPosition.ts
+++ b/src/utils/getPerpsPosition.ts
@@ -8,7 +8,6 @@ export default function getPerpsPosition(
   tradeDirection: TradeDirection,
   tradingFee: PerpsTradingFee,
   currentPerpPosition?: PerpsPosition,
-  limitPrice?: BigNumber,
 ): PerpsPosition {
   if (currentPerpPosition) {
     return {


### PR DESCRIPTION
This PR fixes the perp position preview in the account summary and the text inside the perp position summary modal.