### PR TITLE
feature: add dynamic decimal places

### DIFF
--- a/src/components/account/AccountBalancesTable/Columns/LiqPrice.tsx
+++ b/src/components/account/AccountBalancesTable/Columns/LiqPrice.tsx
@@ -71,6 +71,7 @@ export default function LiqPrice(props: Props) {
       options={{
         abbreviated: false,
         maxDecimals: getPriceDecimals(liqPrice),
+        minDecimals: getPriceDecimals(liqPrice),
       }}
       showDetailedPrice
     />

--- a/src/components/account/AccountBalancesTable/Columns/LiqPrice.tsx
+++ b/src/components/account/AccountBalancesTable/Columns/LiqPrice.tsx
@@ -72,6 +72,7 @@ export default function LiqPrice(props: Props) {
         abbreviated: false,
         maxDecimals: getPriceDecimals(liqPrice),
       }}
+      showDetailedPrice
     />
   )
 }

--- a/src/components/account/AccountBalancesTable/Columns/LiqPrice.tsx
+++ b/src/components/account/AccountBalancesTable/Columns/LiqPrice.tsx
@@ -8,6 +8,7 @@ import useLiquidationPrice from 'hooks/prices/useLiquidationPrice'
 import { BNCoin } from 'types/classes/BNCoin'
 import { LiquidationPriceKind } from 'utils/health_computer'
 import { BN } from 'utils/helpers'
+import { getPriceDecimals } from 'utils/formatters'
 
 export const LIQ_META = {
   accessorKey: 'symbol',
@@ -67,7 +68,10 @@ export default function LiqPrice(props: Props) {
     <DisplayCurrency
       className='text-xs text-right number'
       coin={BNCoin.fromDenomAndBigNumber('usd', BN(liqPrice))}
-      options={{ abbreviated: false, maxDecimals: liqPrice >= 10 ? 2 : 6 }}
+      options={{
+        abbreviated: false,
+        maxDecimals: getPriceDecimals(liqPrice),
+      }}
     />
   )
 }

--- a/src/components/account/AccountDetails/index.tsx
+++ b/src/components/account/AccountDetails/index.tsx
@@ -34,7 +34,6 @@ import {
   calculateAccountBalanceValue,
   calculateAccountLeverage,
 } from 'utils/accounts'
-import { getPriceDecimals } from 'utils/formatters'
 
 interface Props {
   account: Account
@@ -190,14 +189,7 @@ function AccountDetails(props: Props) {
               >
                 Net worth
               </Text>
-              <DisplayCurrency
-                coin={coin}
-                className='w-full text-center truncate text-2xs'
-                options={{
-                  maxDecimals: getPriceDecimals(coin.amount),
-                  abbreviated: false,
-                }}
-              />
+              <DisplayCurrency coin={coin} className='w-full text-center truncate text-2xs ' />
             </div>
             <div className='w-full py-4 border-t border-white/20'>
               <Text size='2xs' className='mb-0.5 w-full text-center text-white/50'>

--- a/src/components/account/AccountDetails/index.tsx
+++ b/src/components/account/AccountDetails/index.tsx
@@ -34,6 +34,7 @@ import {
   calculateAccountBalanceValue,
   calculateAccountLeverage,
 } from 'utils/accounts'
+import { getPriceDecimals } from 'utils/formatters'
 
 interface Props {
   account: Account
@@ -189,7 +190,14 @@ function AccountDetails(props: Props) {
               >
                 Net worth
               </Text>
-              <DisplayCurrency coin={coin} className='w-full text-center truncate text-2xs ' />
+              <DisplayCurrency
+                coin={coin}
+                className='w-full text-center truncate text-2xs'
+                options={{
+                  maxDecimals: getPriceDecimals(coin.amount),
+                  abbreviated: false,
+                }}
+              />
             </div>
             <div className='w-full py-4 border-t border-white/20'>
               <Text size='2xs' className='mb-0.5 w-full text-center text-white/50'>

--- a/src/components/perps/BalancesTable/Columns/EntryPrice.tsx
+++ b/src/components/perps/BalancesTable/Columns/EntryPrice.tsx
@@ -46,6 +46,7 @@ export default function EntryPrice(props: Props) {
           coin={BNCoin.fromDenomAndBigNumber('usd', currentPrice ?? 0)}
           options={{
             maxDecimals: getPriceDecimals(currentPrice),
+            minDecimals: getPriceDecimals(currentPrice),
             abbreviated: false,
           }}
           showDetailedPrice

--- a/src/components/perps/BalancesTable/Columns/EntryPrice.tsx
+++ b/src/components/perps/BalancesTable/Columns/EntryPrice.tsx
@@ -3,6 +3,7 @@ import Text from 'components/common/Text'
 import TitleAndSubCell from 'components/common/TitleAndSubCell'
 import { PRICE_ORACLE_DECIMALS } from 'constants/query'
 import { BNCoin } from 'types/classes/BNCoin'
+import { getPriceDecimals } from 'utils/formatters'
 
 export const ENTRY_PRICE_META = {
   accessorKey: 'entryPrice',
@@ -34,18 +35,20 @@ export default function EntryPrice(props: Props) {
         <DisplayCurrency
           coin={BNCoin.fromDenomAndBigNumber('usd', entryPrice ?? 0)}
           options={{
-            maxDecimals: entryPrice.isGreaterThanOrEqualTo(10) ? 2 : 6,
+            maxDecimals: getPriceDecimals(entryPrice),
             abbreviated: false,
           }}
+          showDetailedPrice
         />
       }
       sub={
         <DisplayCurrency
           coin={BNCoin.fromDenomAndBigNumber('usd', currentPrice ?? 0)}
           options={{
-            maxDecimals: entryPrice.isGreaterThanOrEqualTo(10) ? 2 : 6,
+            maxDecimals: getPriceDecimals(currentPrice),
             abbreviated: false,
           }}
+          showDetailedPrice
         />
       }
     />

--- a/src/components/perps/BalancesTable/Columns/Leverage.tsx
+++ b/src/components/perps/BalancesTable/Columns/Leverage.tsx
@@ -28,7 +28,7 @@ export default function Leverage(props: Props) {
 
   return (
     <TitleAndSubCell
-      title={liqPrice.toString() ?? '-'}
+      title={liqPrice ? `$${liqPrice.toString()}` : '-'}
       sub={
         props.leverage ? <FormattedNumber amount={props.leverage} options={{ suffix: 'x' }} /> : ''
       }

--- a/src/components/perps/BalancesTable/Columns/Size.tsx
+++ b/src/components/perps/BalancesTable/Columns/Size.tsx
@@ -5,7 +5,7 @@ import { FormattedNumber } from 'components/common/FormattedNumber'
 import Text from 'components/common/Text'
 import TitleAndSubCell from 'components/common/TitleAndSubCell'
 import { BNCoin } from 'types/classes/BNCoin'
-import { demagnify } from 'utils/formatters'
+import { demagnify, getPriceDecimals } from 'utils/formatters'
 
 export const SIZE_META = {
   accessorKey: 'size',
@@ -41,7 +41,15 @@ export default function Size(props: Props) {
           className='text-xs'
         />
       }
-      sub={<DisplayCurrency coin={BNCoin.fromDenomAndBigNumber('usd', value)} />}
+      sub={
+        <DisplayCurrency
+          coin={BNCoin.fromDenomAndBigNumber('usd', value)}
+          options={{
+            maxDecimals: getPriceDecimals(value),
+            abbreviated: false,
+          }}
+        />
+      }
     />
   )
 }

--- a/src/components/perps/BalancesTable/Columns/Size.tsx
+++ b/src/components/perps/BalancesTable/Columns/Size.tsx
@@ -46,6 +46,7 @@ export default function Size(props: Props) {
           coin={BNCoin.fromDenomAndBigNumber('usd', value)}
           options={{
             maxDecimals: getPriceDecimals(value),
+            minDecimals: 0,
             abbreviated: false,
           }}
         />

--- a/src/components/perps/Module/ExpectedPrice.tsx
+++ b/src/components/perps/Module/ExpectedPrice.tsx
@@ -29,6 +29,7 @@ export const ExpectedPrice = (props: Props) => {
       coin={BNCoin.fromDenomAndBigNumber('usd', override ? override : price)}
       options={{ maxDecimals: getPriceDecimals(override ? override : price), abbreviated: false }}
       className={className}
+      showDetailedPrice
     />
   )
 }

--- a/src/components/perps/Module/ExpectedPrice.tsx
+++ b/src/components/perps/Module/ExpectedPrice.tsx
@@ -5,6 +5,7 @@ import usePerpsEnabledAssets from 'hooks/assets/usePerpsEnabledAssets'
 import useTradingFeeAndPrice from 'hooks/perps/useTradingFeeAndPrice'
 import { BNCoin } from 'types/classes/BNCoin'
 import { byDenom } from 'utils/array'
+import { getPriceDecimals } from 'utils/formatters'
 
 type Props = {
   denom: string
@@ -26,7 +27,7 @@ export const ExpectedPrice = (props: Props) => {
   return (
     <DisplayCurrency
       coin={BNCoin.fromDenomAndBigNumber('usd', override ? override : price)}
-      options={{ maxDecimals: price.isGreaterThan(10) ? 2 : 6, abbreviated: false }}
+      options={{ maxDecimals: getPriceDecimals(override ? override : price), abbreviated: false }}
       className={className}
     />
   )

--- a/src/components/perps/Module/Summary.tsx
+++ b/src/components/perps/Module/Summary.tsx
@@ -31,7 +31,7 @@ import useStore from 'store'
 import { BNCoin } from 'types/classes/BNCoin'
 import { OrderType } from 'types/enums'
 import { byDenom } from 'utils/array'
-import { formatLeverage, magnify } from 'utils/formatters'
+import { formatLeverage, getPriceDecimals, magnify } from 'utils/formatters'
 import { BN } from 'utils/helpers'
 
 type Props = {
@@ -378,7 +378,10 @@ function ManageSummary(
             priceOverride ? 'usd' : asset.denom,
             priceOverride ? size.times(priceOverride).shiftedBy(-asset.decimals) : size,
           )}
-          options={{ abbreviated: false }}
+          options={{
+            maxDecimals: getPriceDecimals(priceOverride ?? size),
+            abbreviated: false,
+          }}
         />
       </SummaryLine>
       <SummaryLine label='Leverage' contentClassName='flex gap-1 pt-2'>

--- a/src/components/perps/Module/TradingFee.tsx
+++ b/src/components/perps/Module/TradingFee.tsx
@@ -2,6 +2,7 @@ import { CircularProgress } from 'components/common/CircularProgress'
 import DisplayCurrency from 'components/common/DisplayCurrency'
 import useTradingFeeAndPrice from 'hooks/perps/useTradingFeeAndPrice'
 import { BNCoin } from 'types/classes/BNCoin'
+import { getPriceDecimals } from 'utils/formatters'
 
 type Props = {
   denom: string
@@ -26,6 +27,7 @@ export default function TradingFee(props: Props) {
   const fee = tradingFeeAndPrice.fee.opening
     .plus(tradingFeeAndPrice.fee.closing)
     .plus(keeperFee?.amount ?? 0)
+
   return (
     <DisplayCurrency
       coin={BNCoin.fromDenomAndBigNumber(
@@ -34,6 +36,11 @@ export default function TradingFee(props: Props) {
       )}
       className={className}
       showSignPrefix={!!showPrefix}
+      showDetailedPrice
+      options={{
+        maxDecimals: getPriceDecimals(fee),
+        abbreviated: false,
+      }}
     />
   )
 }

--- a/src/components/portfolio/Overview/Summary.tsx
+++ b/src/components/portfolio/Overview/Summary.tsx
@@ -117,7 +117,16 @@ export default function PortfolioSummary() {
         sub: 'Combined leverage',
       },
     ]
-  }, [allAccounts, assets, borrowAssets, lendingAssets, vaultAprs, astroLpAprs, assetParams])
+  }, [
+    allAccounts,
+    assets,
+    borrowAssets,
+    lendingAssets,
+    vaultAprs,
+    astroLpAprs,
+    assetParams,
+    perpsVault?.apy,
+  ])
 
   if (!walletAddress && !urlAddress) return null
 

--- a/src/components/trade/TradeChart/index.tsx
+++ b/src/components/trade/TradeChart/index.tsx
@@ -30,7 +30,7 @@ import {
   ResolutionString,
   widget,
 } from 'utils/charting_library'
-import { formatValue, magnify } from 'utils/formatters'
+import { formatValue, getPriceDecimals, magnify } from 'utils/formatters'
 import { getTradingViewSettings } from 'utils/theme'
 
 interface Props {
@@ -309,7 +309,7 @@ export default function TradeChart(props: Props) {
                     prefix: '= ',
                     suffix: ` USD`,
                     abbreviated: false,
-                    maxDecimals: props.buyAsset.decimals,
+                    maxDecimals: getPriceDecimals(props.buyAsset?.price?.amount),
                   }}
                 />
               ) : (
@@ -321,7 +321,7 @@ export default function TradeChart(props: Props) {
                       prefix: '= ',
                       suffix: ` ${props.sellAsset.symbol}`,
                       abbreviated: false,
-                      maxDecimals: props.sellAsset.decimals,
+                      maxDecimals: getPriceDecimals(props.sellAsset.price?.amount),
                     }}
                   />
 


### PR DESCRIPTION
Updated price formatting logic to show actual values for small numbers (< $0.01) instead of displaying $0.00. Also created a `getPriceDecimals` function to dynamically calculate needed decimal places and added `showDetailedPrice` prop to `DisplayCurrency` components where appropriate in the Perps modules primarily.