### PR TITLE
Perps stop order

### DIFF
--- a/src/chains/neutron/pion-1.ts
+++ b/src/chains/neutron/pion-1.ts
@@ -29,8 +29,8 @@ const Pion1: ChainConfig = {
     rest: process.env.NEXT_PUBLIC_NEUTRON_TEST_REST ?? 'https://rest-palvus.pion-1.ntrn.tech',
     swap: 'https://testnet-neutron.astroport.fi/swap',
     explorer: 'https://www.mintscan.io/neutron-testnet',
-    dexAssets: 'https://neutron-cache-api.onrender.com/tokens',
-    dexPools: 'https://neutron-cache-api.onrender.com/pools',
+    dexAssets: 'https://neutron-cache-api.onrender.com/pion-1/tokens',
+    dexPools: 'https://neutron-cache-api.onrender.com/pion-1/pools',
     gasPrices: '/feemarket/v1/gas_price/untrn',
     aprs: {
       vaults: '',

--- a/src/components/perps/BalancesTable/Columns/Manage.tsx
+++ b/src/components/perps/BalancesTable/Columns/Manage.tsx
@@ -3,7 +3,12 @@ import { useSearchParams } from 'react-router-dom'
 
 import ActionButton from 'components/common/Button/ActionButton'
 import DropDownButton from 'components/common/Button/DropDownButton'
-import { Check, Cross, Edit } from 'components/common/Icons'
+import {
+  Check,
+  Cross,
+  Edit,
+  //  Shield
+} from 'components/common/Icons'
 import Text from 'components/common/Text'
 import PerpsSlTpModal from 'components/Modals/PerpsSlTpModal'
 import CloseLabel from 'components/perps/BalancesTable/Columns/CloseLabel'
@@ -134,7 +139,7 @@ export default function Manage(props: Props) {
             // Remove SL/TP for the moment
             // {
             //   icon: <Shield />,
-            //   text: 'Add SL/TP',
+            //   text: 'Add Stop Loss',
             //   onClick: openPerpsSlTpModal,
             // },
           ]
@@ -152,7 +157,7 @@ export default function Manage(props: Props) {
             },
             // {
             //   icon: <Shield />,
-            //   text: 'Add SL/TP',
+            //   text: 'Add Stop Loss',
             //   onClick: openPerpsSlTpModal,
             // },
           ]),

--- a/src/components/perps/BalancesTable/Columns/Manage.tsx
+++ b/src/components/perps/BalancesTable/Columns/Manage.tsx
@@ -100,8 +100,8 @@ export default function Manage(props: Props) {
         ),
         content: (
           <Text>
-            Closing this position will also cancel all related limit orders. Do
-            you want to continue?
+            Closing this position will also cancel all related limit orders. Do you want to
+            continue?
           </Text>
         ),
         positiveButton: {

--- a/src/components/perps/BalancesTable/Columns/Manage.tsx
+++ b/src/components/perps/BalancesTable/Columns/Manage.tsx
@@ -100,7 +100,7 @@ export default function Manage(props: Props) {
         ),
         content: (
           <Text>
-            Closing this position will also cancel all related stop-loss and take-profit orders. Do
+            Closing this position will also cancel all related limit orders. Do
             you want to continue?
           </Text>
         ),

--- a/src/components/perps/BalancesTable/Columns/usePerpsBalancesColumns.tsx
+++ b/src/components/perps/BalancesTable/Columns/usePerpsBalancesColumns.tsx
@@ -11,11 +11,11 @@ import TradeDirection, {
   PERP_TYPE_META,
 } from 'components/perps/BalancesTable/Columns/TradeDirection'
 import { Type, TYPE_META } from 'components/perps/BalancesTable/Columns/Type'
+import { PRICE_ORACLE_DECIMALS } from 'constants/query'
 import usePerpsLimitOrderRows from 'hooks/perps/usePerpsLimitOrdersRows'
 import { demagnify } from 'utils/formatters'
 import { BN } from 'utils/helpers'
 import { checkStopLossAndTakeProfit } from 'utils/perps'
-import { PRICE_ORACLE_DECIMALS } from 'constants/query'
 
 interface Props {
   isOrderTable: boolean
@@ -93,7 +93,7 @@ export default function usePerpsBalancesColumns(props: Props) {
         cell: ({ row }) => <Manage perpPosition={row.original} />,
       },
     ],
-    [],
+    [isOrderTable],
   )
 
   const typeColumn = useMemo<ColumnDef<PerpPositionRow>>(

--- a/src/components/perps/BalancesTable/index.tsx
+++ b/src/components/perps/BalancesTable/index.tsx
@@ -57,7 +57,7 @@ export default function PerpsBalancesTable() {
         ),
       },
     ],
-    [columns, activePerpsPositions, onClickRow, activeLimitOrders],
+    [activeLimitOrders, columns, activePerpsPositions, onClickRow, limitOrderColumns],
   )
 
   if (!activePerpsPositions.length && !activeLimitOrders.length) return null

--- a/src/components/perps/Module/PerpsModule.tsx
+++ b/src/components/perps/Module/PerpsModule.tsx
@@ -229,8 +229,7 @@ export function PerpsModule() {
 
   useEffect(() => {
     if (!tradingFee || !perpsVault || perpsVaultModal) return
-    if (isLimitOrder) {
-      simulatePerps(currentPerpPosition, isAutoLendEnabledForCurrentAccount)
+    if (isLimitOrder || isStopOrder) {
       return
     }
     const newAmount = currentPerpPosition?.amount.plus(amount) ?? amount
@@ -253,6 +252,7 @@ export function PerpsModule() {
     currentPerpPosition,
     isAutoLendEnabledForCurrentAccount,
     isLimitOrder,
+    isStopOrder,
     limitPrice,
     perpsAsset,
     perpsVault,
@@ -326,6 +326,13 @@ export function PerpsModule() {
     return amount.isGreaterThan(maxAmount)
   }, [amount, maxAmount])
 
+  const oppositeTradeDirection = useMemo(() => {
+    if (!currentPerpPosition) return 'long'
+    return currentPerpPosition.tradeDirection === 'long' ? 'short' : 'long'
+  }, [currentPerpPosition])
+
+  const effectiveTradeDirection = isStopOrder ? oppositeTradeDirection : tradeDirection
+
   if (!perpsAsset) return null
 
   return (
@@ -350,10 +357,12 @@ export function PerpsModule() {
           selected={selectedOrderType}
           onChange={onChangeOrderType}
         />
-        <TradeDirectionSelector
-          direction={tradeDirection}
-          onChangeDirection={onChangeTradeDirection}
-        />
+        {!isStopOrder && (
+          <TradeDirectionSelector
+            direction={tradeDirection}
+            onChangeDirection={onChangeTradeDirection}
+          />
+        )}
 
         {isLimitOrder && USD && (
           <>

--- a/src/components/perps/Module/PerpsModule.tsx
+++ b/src/components/perps/Module/PerpsModule.tsx
@@ -261,12 +261,6 @@ export function PerpsModule() {
     tradingFee,
   ])
 
-  useEffect(() => {
-    if ((isStopOrder || isLimitOrder) && currentPerpPosition) {
-      setTradeDirection(currentPerpPosition.tradeDirection === 'long' ? 'short' : 'long')
-    }
-  }, [isStopOrder, isLimitOrder, currentPerpPosition])
-
   const isDisabledExecution = useMemo(() => {
     const baseConditions =
       amount.isZero() || amount.isGreaterThan(maxAmount) || warningMessages.isNotEmpty()

--- a/src/components/perps/Module/Summary.tsx
+++ b/src/components/perps/Module/Summary.tsx
@@ -124,18 +124,21 @@ export default function PerpsSummary(props: Props) {
 
     if (isStopOrder && calculateKeeperFee) {
       let comparison: 'less_than' | 'greater_than'
+      let stopTradeDirection: 'long' | 'short'
 
       if (tradeDirection === 'long') {
         comparison = 'less_than'
+        stopTradeDirection = 'short'
       } else {
         comparison = 'greater_than'
+        stopTradeDirection = 'long'
       }
 
       await submitLimitOrder({
         asset,
-        orderSize: orderSize.abs(),
+        orderSize: orderSize,
         limitPrice: stopPrice,
-        tradeDirection,
+        tradeDirection: stopTradeDirection,
         baseDenom,
         keeperFee: calculateKeeperFee,
         isReduceOnly: true,
@@ -286,6 +289,12 @@ export default function PerpsSummary(props: Props) {
     close,
     setShowSummary,
   ])
+
+  const submitBtnText = useMemo(() => {
+    if (isStopOrder) return 'Create Stop Order'
+    if (isLimitOrder) return 'Create Limit Order'
+  }, [isStopOrder, isLimitOrder])
+
   if (!account) return null
 
   return (
@@ -334,8 +343,8 @@ export default function PerpsSummary(props: Props) {
         disabled={isDisabled}
         className='w-full py-2.5 !text-base'
       >
-        {isLimitOrder ? (
-          'Create Limit Order'
+        {isLimitOrder || isStopOrder ? (
+          submitBtnText
         ) : (
           <>
             <span className='mr-1 capitalize'>{tradeDirection}</span>

--- a/src/components/perps/Module/constants.ts
+++ b/src/components/perps/Module/constants.ts
@@ -9,10 +9,21 @@ export const PERPS_ORDER_TYPE_TABS: OrderTab[] = [
     type: OrderType.LIMIT,
     isDisabled: false,
   },
+  {
+    type: OrderType.STOP,
+    isDisabled: false,
+    tooltipText: ORDER_TYPE_UNAVAILABLE_MESSAGE,
+  },
 ]
 
 export const DEFAULT_LIMIT_PRICE_INFO: CallOut = {
   message:
     'In order to create a limit order please specify a price. As soon as the price is hit, the transaction will be executed.',
+  type: CalloutType.INFO,
+}
+
+export const DEFAULT_STOP_PRICE_INFO: CallOut = {
+  message:
+    'In order to create a stop order please specify a price. As soon as the price is hit, the transaction will be executed.',
   type: CalloutType.INFO,
 }

--- a/src/components/portfolio/Account/Summary.tsx
+++ b/src/components/portfolio/Account/Summary.tsx
@@ -88,7 +88,17 @@ function Content(props: Props) {
         sub: props.v1 ? 'Total Leverage' : DEFAULT_PORTFOLIO_STATS[5].sub,
       },
     ]
-  }, [account, assets, borrowAssets, lendingAssets, vaultAprs, props.v1, astroLpAprs, assetParams])
+  }, [
+    account,
+    borrowAssets,
+    lendingAssets,
+    assets,
+    vaultAprs,
+    astroLpAprs,
+    assetParams.data,
+    perpsVault?.apy,
+    props.v1,
+  ])
 
   return (
     <Skeleton

--- a/src/hooks/perps/usePerpsOrderForm.ts
+++ b/src/hooks/perps/usePerpsOrderForm.ts
@@ -4,7 +4,7 @@ import { OrderType } from 'types/enums'
 
 interface PerpsOrderFormState {
   limitPrice: BigNumber
-  orderType: 'market' | 'limit'
+  orderType: 'market' | 'limit' | 'stop'
   selectedOrderType: OrderType
   setLimitPrice: (price: BigNumber, fromTradingView?: boolean) => void
   setOrderType: (type: 'market' | 'limit') => void

--- a/src/utils/perps.ts
+++ b/src/utils/perps.ts
@@ -94,14 +94,14 @@ export const validateStopOrderPrice = (
   }
 
   if (tradeDirection === 'long') {
-    if (stopPrice.isGreaterThanOrEqualTo(currentPrice)) {
+    if (stopPrice.isLessThanOrEqualTo(currentPrice)) {
       return {
         isValid: false,
         errorMessage: 'Stop price must be below current price for long positions',
       }
     }
   } else {
-    if (stopPrice.isLessThanOrEqualTo(currentPrice)) {
+    if (stopPrice.isGreaterThanOrEqualTo(currentPrice)) {
       return {
         isValid: false,
         errorMessage: 'Stop price must be above current price for short positions',

--- a/src/utils/perps.ts
+++ b/src/utils/perps.ts
@@ -83,3 +83,31 @@ export const convertTriggerOrderResponseToPerpPosition = (
     leverage: 1,
   }
 }
+
+export const validateStopOrderPrice = (
+  stopPrice: BigNumber,
+  currentPrice: BigNumber,
+  tradeDirection: TradeDirection,
+): { isValid: boolean; errorMessage: string | null } => {
+  if (stopPrice.isZero() || currentPrice.isZero()) {
+    return { isValid: false, errorMessage: null }
+  }
+
+  if (tradeDirection === 'long') {
+    if (stopPrice.isGreaterThanOrEqualTo(currentPrice)) {
+      return {
+        isValid: false,
+        errorMessage: 'Stop price must be below current price for long positions',
+      }
+    }
+  } else {
+    if (stopPrice.isLessThanOrEqualTo(currentPrice)) {
+      return {
+        isValid: false,
+        errorMessage: 'Stop price must be above current price for short positions',
+      }
+    }
+  }
+
+  return { isValid: true, errorMessage: null }
+}


### PR DESCRIPTION
Added stop order functionality by duplicating and inverting limit order logic, ensuring proper price validation based on position direction.

Position flipping safety by automatically cancelling all open limit orders when positions are flipped. 

Added warning dialog when closing positions with active orders.