### PR TITLE
refactor: Update default route in Routes component

### DIFF
--- a/src/components/header/navigation/Routes.tsx
+++ b/src/components/header/navigation/Routes.tsx
@@ -37,7 +37,12 @@ export default function Routes() {
         <Route path='/v1' element={<V1Page />} />
         <Route path='/hls-staking' element={<HlsStakingPage />} />
         <Route path='/hls-farm' element={<HlsFarmPage />} />
-        <Route path='/' element={<TradePage />} />
+        <Route
+          path='/'
+          element={
+            chainConfig.perps ? <Navigate to='/perps' replace /> : <Navigate to='/trade' replace />
+          }
+        />
         <Route path='/wallets/:address'>
           <Route path='execute' element={<ExecuteMessagePage />} />
           <Route path='trade' element={<TradePage />} />


### PR DESCRIPTION
This commit updates the default route in the Routes component. Instead of rendering the TradePage component as the default route, it now checks the chain configuration and renders either the PerpsPage or the TradePage component accordingly. This change ensures that the correct default page is displayed based on the chain configuration.