### PR TITLE
v2.8.11

### DIFF
--- a/src/utils/astroLps.ts
+++ b/src/utils/astroLps.ts
@@ -60,7 +60,10 @@ export function getAstroLpSharesFromCoinsValue(
   const astroLpAsset = assets.find(byDenom(astroLp.denoms.lp))
   if (!astroLpAsset || !astroLpAsset.price) return BN_ZERO
 
-  return coinsValue.dividedBy(astroLpAsset.price.amount).shiftedBy(astroLpAsset.decimals)
+  return coinsValue
+    .dividedBy(astroLpAsset.price.amount)
+    .shiftedBy(astroLpAsset.decimals)
+    .decimalPlaces(0)
 }
 
 export function getAstroLpCoinsFromShares(


### PR DESCRIPTION
### Bugfix
- `astroLpShares` had a decimal in the amount of its `Coin` object, which crashed the Health Computer