### PR TITLE
Perps position label

### DIFF
--- a/src/components/Modals/AlertDialog/index.tsx
+++ b/src/components/Modals/AlertDialog/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 
 import Button from 'components/common/Button'
 import Checkbox from 'components/common/Checkbox'
+import EscButton from 'components/common/Button/EscButton'
 import Text from 'components/common/Text'
 import { NoIcon, YesIcon } from 'components/Modals/AlertDialog/ButtonIcons'
 import Modal from 'components/Modals/Modal'
@@ -22,7 +23,17 @@ interface Props {
 }
 
 function AlertDialog(props: Props) {
-  const { title, icon, content, negativeButton, positiveButton, checkbox, header } = props.config
+  const {
+    title,
+    icon,
+    content,
+    negativeButton,
+    positiveButton,
+    checkbox,
+    header,
+    isSingleButtonLayout,
+    showCloseButton,
+  } = props.config
 
   const [toggle, handleToggle] = useToggle()
 
@@ -42,7 +53,10 @@ function AlertDialog(props: Props) {
       hideTxLoader
       header={
         header ? (
-          header
+          <div className='flex items-center justify-between w-full'>
+            {header}
+            {showCloseButton && <EscButton onClick={props.close} />}
+          </div>
         ) : (
           <div className='flex flex-col'>
             {icon && (
@@ -65,42 +79,67 @@ function AlertDialog(props: Props) {
       ) : (
         content
       )}
-      <div
-        className={classNames(
-          'mt-10 flex justify-between gap-4 md:flex-nowrap flex-wrap',
-          positiveButton && 'flex-row-reverse',
-        )}
-      >
-        <div className='flex flex-row-reverse gap-4'>
+      {isSingleButtonLayout ? (
+        <div className='mt-10 flex flex-col gap-4'>
+          {checkbox && (
+            <div className='flex justify-center'>
+              <Checkbox
+                name='hls-info-toggle'
+                checked={toggle}
+                onChange={handleCheckboxClick}
+                text={checkbox.text}
+              />
+            </div>
+          )}
           {positiveButton && (
             <Button
-              text={positiveButton.text ?? 'Yes'}
-              color='tertiary'
-              className='px-6'
-              rightIcon={positiveButton.icon ?? <YesIcon />}
-              iconClassName='h-4 w-5'
+              text={positiveButton.text ?? 'Continue'}
+              color='primary'
+              className='w-full'
+              rightIcon={positiveButton.icon}
               onClick={() => handleButtonClick(positiveButton)}
               disabled={positiveButton.disabled}
             />
           )}
-          {checkbox && (
-            <Checkbox
-              name='hls-info-toggle'
-              checked={toggle}
-              onChange={handleCheckboxClick}
-              text={checkbox.text}
-            />
-          )}
         </div>
-        <Button
-          text={negativeButton?.text ?? 'No'}
-          color='secondary'
-          className='px-6'
-          rightIcon={negativeButton?.icon ?? <NoIcon />}
-          tabIndex={1}
-          onClick={() => handleButtonClick(negativeButton)}
-        />
-      </div>
+      ) : (
+        <div
+          className={classNames(
+            'mt-10 flex justify-between gap-4 md:flex-nowrap flex-wrap',
+            positiveButton && 'flex-row-reverse',
+          )}
+        >
+          <div className='flex flex-row-reverse gap-4'>
+            {positiveButton && (
+              <Button
+                text={positiveButton.text ?? 'Yes'}
+                color='tertiary'
+                className='px-6'
+                rightIcon={positiveButton.icon ?? <YesIcon />}
+                iconClassName='h-4 w-5'
+                onClick={() => handleButtonClick(positiveButton)}
+                disabled={positiveButton.disabled}
+              />
+            )}
+            {checkbox && (
+              <Checkbox
+                name='hls-info-toggle'
+                checked={toggle}
+                onChange={handleCheckboxClick}
+                text={checkbox.text}
+              />
+            )}
+          </div>
+          <Button
+            text={negativeButton?.text ?? 'No'}
+            color='secondary'
+            className='px-6'
+            rightIcon={negativeButton?.icon ?? <NoIcon />}
+            tabIndex={1}
+            onClick={() => handleButtonClick(negativeButton)}
+          />
+        </div>
+      )}
     </Modal>
   )
 }

--- a/src/components/perps/BalancesTable/Columns/Manage.tsx
+++ b/src/components/perps/BalancesTable/Columns/Manage.tsx
@@ -3,11 +3,9 @@ import { useSearchParams } from 'react-router-dom'
 
 import ActionButton from 'components/common/Button/ActionButton'
 import DropDownButton from 'components/common/Button/DropDownButton'
-import { Check, Cross, Edit, SwapIcon } from 'components/common/Icons'
+import { ArrowRight, Cross, Edit, SwapIcon } from 'components/common/Icons'
 import Text from 'components/common/Text'
 import PerpsSlTpModal from 'components/Modals/PerpsSlTpModal'
-import CloseLabel from 'components/perps/BalancesTable/Columns/CloseLabel'
-import TradeDirection from 'components/perps/BalancesTable/Columns/TradeDirection'
 import ConfirmationSummary from 'components/perps/Module/ConfirmationSummary'
 import { getDefaultChainSettings } from 'constants/defaultSettings'
 import { LocalStorageKeys } from 'constants/localStorageKeys'
@@ -89,11 +87,7 @@ export default function Manage(props: Props) {
 
     if (!showSummary && hasOpenOrders) {
       openAlertDialog({
-        header: (
-          <div className='flex items-center justify-between w-full'>
-            <Text size='2xl'>Warning</Text>
-          </div>
-        ),
+        header: <Text size='2xl'>Warning</Text>,
         content: (
           <Text>
             Closing this position will also cancel all related limit orders. Do you want to
@@ -102,13 +96,14 @@ export default function Manage(props: Props) {
         ),
         positiveButton: {
           text: 'Continue',
-          icon: <Check />,
+          icon: <ArrowRight />,
           onClick: closePosition,
         },
         negativeButton: {
           text: 'Cancel',
           onClick: close,
         },
+        showCloseButton: true,
       })
       return
     }
@@ -119,12 +114,7 @@ export default function Manage(props: Props) {
     }
 
     openAlertDialog({
-      header: (
-        <div className='flex items-center justify-between w-full'>
-          <Text size='2xl'>Order Summary</Text>
-          <CloseLabel className='capitalize !text-sm' />
-        </div>
-      ),
+      header: <Text size='2xl'>Order Summary</Text>,
       content: (
         <ConfirmationSummary
           amount={perpPosition.amount.negated()}
@@ -135,19 +125,15 @@ export default function Manage(props: Props) {
       ),
       positiveButton: {
         text: 'Confirm',
-        icon: <Check />,
+        icon: <ArrowRight />,
         onClick: closePosition,
-      },
-      negativeButton: {
-        text: 'Cancel',
-        onClick: () => {
-          close()
-        },
       },
       checkbox: {
         text: 'Hide summary in the future',
         onClick: (isChecked: boolean) => setShowSummary(!isChecked),
       },
+      isSingleButtonLayout: true,
+      showCloseButton: true,
     })
   }, [
     close,
@@ -185,11 +171,7 @@ export default function Manage(props: Props) {
 
       if (!showSummary && hasOpenOrders) {
         openAlertDialog({
-          header: (
-            <div className='flex items-center justify-between w-full'>
-              <Text size='2xl'>Warning</Text>
-            </div>
-          ),
+          header: <Text size='2xl'>Warning</Text>,
           content: (
             <Text>
               Flipping this position will also cancel all related limit orders. Do you want to
@@ -198,13 +180,14 @@ export default function Manage(props: Props) {
           ),
           positiveButton: {
             text: 'Continue',
-            icon: <Check />,
+            icon: <ArrowRight />,
             onClick: executeFlip,
           },
           negativeButton: {
             text: 'Cancel',
             onClick: close,
           },
+          showCloseButton: true,
         })
         return
       }
@@ -215,12 +198,7 @@ export default function Manage(props: Props) {
       }
 
       openAlertDialog({
-        header: (
-          <div className='flex items-center justify-between w-full'>
-            <Text size='2xl'>Order Summary</Text>
-            <TradeDirection tradeDirection={newDirection} type='market' />
-          </div>
-        ),
+        header: <Text size='2xl'>Order Summary</Text>,
         content: (
           <ConfirmationSummary
             amount={signedAmount}
@@ -230,20 +208,16 @@ export default function Manage(props: Props) {
           />
         ),
         positiveButton: {
-          text: 'Confirm',
-          icon: <Check />,
+          text: 'Continue',
+          icon: <ArrowRight />,
           onClick: executeFlip,
-        },
-        negativeButton: {
-          text: 'Cancel',
-          onClick: () => {
-            close()
-          },
         },
         checkbox: {
           text: 'Hide summary in the future',
           onClick: (isChecked: boolean) => setShowSummary(!isChecked),
         },
+        isSingleButtonLayout: true,
+        showCloseButton: true,
       })
     },
     [

--- a/src/components/perps/Module/ConfirmationSummary.tsx
+++ b/src/components/perps/Module/ConfirmationSummary.tsx
@@ -53,7 +53,7 @@ interface ActionLabelProps {
 
 function ActionLabel({ text, tradeDirection, isLimitOrder, showCloseLabel }: ActionLabelProps) {
   return (
-    <div className='flex items-center gap-2'>
+    <div className='flex justify-between items-center'>
       <Text>{text}</Text>
       {showCloseLabel ? (
         <CloseLabel className='capitalize !text-sm' />

--- a/src/components/perps/Module/Summary.tsx
+++ b/src/components/perps/Module/Summary.tsx
@@ -9,7 +9,6 @@ import { ArrowRight, Check } from 'components/common/Icons'
 import SummaryLine from 'components/common/SummaryLine'
 import Text from 'components/common/Text'
 import AssetAmount from 'components/common/assets/AssetAmount'
-import CloseLabel from 'components/perps/BalancesTable/Columns/CloseLabel'
 import TradeDirection from 'components/perps/BalancesTable/Columns/TradeDirection'
 import ConfirmationSummary from 'components/perps/Module/ConfirmationSummary'
 import { ExpectedPrice } from 'components/perps/Module/ExpectedPrice'
@@ -233,19 +232,6 @@ export default function PerpsSummary(props: Props) {
       header: (
         <div className='flex items-center justify-between w-full'>
           <Text size='2xl'>{isLimitOrder ? 'Limit Order Summary' : 'Order Summary'}</Text>
-          {newAmount.isZero() ? (
-            <CloseLabel className='capitalize !text-sm' />
-          ) : (
-            <TradeDirection
-              tradeDirection={
-                isNewPosition || isDirectionChange
-                  ? tradeDirection
-                  : (previousTradeDirection ?? 'long')
-              }
-              type={isLimitOrder ? 'limit' : 'stop'}
-              className='capitalize !text-sm'
-            />
-          )}
         </div>
       ),
       content: (
@@ -279,11 +265,6 @@ export default function PerpsSummary(props: Props) {
     showSummary,
     openAlertDialog,
     isLimitOrder,
-    newAmount,
-    isNewPosition,
-    isDirectionChange,
-    tradeDirection,
-    previousTradeDirection,
     amount,
     asset,
     leverage,

--- a/src/components/perps/Module/Summary.tsx
+++ b/src/components/perps/Module/Summary.tsx
@@ -220,7 +220,7 @@ export default function PerpsSummary(props: Props) {
     [isNewPosition, previousAmount, newAmount],
   )
 
-  const { open: openAlertDialog, close } = useAlertDialog()
+  const { open: openAlertDialog } = useAlertDialog()
 
   const handleOnClick = useCallback(() => {
     if (!currentAccount) return
@@ -245,20 +245,16 @@ export default function PerpsSummary(props: Props) {
         />
       ),
       positiveButton: {
-        text: 'Confirm',
-        icon: <Check />,
+        text: 'Continue',
+        icon: <ArrowRight />,
         onClick: onConfirm,
-      },
-      negativeButton: {
-        text: 'Cancel',
-        onClick: () => {
-          close()
-        },
       },
       checkbox: {
         text: 'Hide summary in the future',
         onClick: (isChecked: boolean) => setShowSummary(!isChecked),
       },
+      isSingleButtonLayout: true,
+      showCloseButton: true,
     })
   }, [
     currentAccount,
@@ -271,7 +267,6 @@ export default function PerpsSummary(props: Props) {
     limitPrice,
     calculateKeeperFee,
     onConfirm,
-    close,
     setShowSummary,
   ])
 

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -1338,6 +1338,8 @@ interface AlertDialogConfig {
   negativeButton?: AlertDialogButton
   positiveButton?: AlertDialogButton
   title?: string
+  isSingleButtonLayout?: boolean
+  showCloseButton?: boolean
 }
 
 interface BorrowModal {


### PR DESCRIPTION
- moved position label from `Summary` into `ConfirmationSummary`  to prevent confusion of trying to close the modal (when Close label is shown)
- implemented full width button

<img width="662" alt="Screenshot 2025-04-15 at 5 46 23 PM" src="https://github.com/user-attachments/assets/a3ccdfcc-dbaa-4ee8-8aa4-f2360441c75a" />
