### PR TITLE
feat: add the subheader to the market stats

### DIFF
--- a/src/components/perps/PerpsTabs.tsx
+++ b/src/components/perps/PerpsTabs.tsx
@@ -1,9 +1,9 @@
 import { CardWithTabs } from 'components/common/Card/CardWithTabs'
 import { PerpsChart } from 'components/perps/PerpsChart'
+import { PerpsInfo } from 'components/perps/PerpsInfo'
 import { PerpsStats } from 'components/perps/PerpsStats'
 import usePerpsAsset from 'hooks/perps/usePerpsAsset'
 import { Suspense, useMemo } from 'react'
-import { PerpsInfo } from './PerpsInfo'
 
 export function PerpsTabs() {
   const { perpsAsset } = usePerpsAsset()

--- a/src/components/perps/PerpsTabs.tsx
+++ b/src/components/perps/PerpsTabs.tsx
@@ -3,6 +3,7 @@ import { PerpsChart } from 'components/perps/PerpsChart'
 import { PerpsStats } from 'components/perps/PerpsStats'
 import usePerpsAsset from 'hooks/perps/usePerpsAsset'
 import { Suspense, useMemo } from 'react'
+import { PerpsInfo } from './PerpsInfo'
 
 export function PerpsTabs() {
   const { perpsAsset } = usePerpsAsset()
@@ -17,11 +18,16 @@ export function PerpsTabs() {
         title: 'Market Stats',
         id: 'stats',
         renderContent: () => (
-          <div className='flex flex-col h-full gap-4'>
-            <Suspense fallback={<div>Loading...</div>}>
-              <PerpsStats denom={perpsAsset.denom} />
-            </Suspense>
-          </div>
+          <>
+            <div className='flex flex-wrap items-center justify-between w-full p-4 bg-white/10'>
+              <PerpsInfo />
+            </div>
+            <div className='flex flex-col h-full gap-4'>
+              <Suspense fallback={<div>Loading...</div>}>
+                <PerpsStats denom={perpsAsset.denom} />
+              </Suspense>
+            </div>
+          </>
         ),
       },
     ],


### PR DESCRIPTION
![Screenshot 2025-04-22 at 11 28 01](https://github.com/user-attachments/assets/2b3d4bbb-a4a7-430f-b146-afb749658c92)
![Screenshot 2025-04-22 at 11 27 50](https://github.com/user-attachments/assets/dd95e470-0ae1-4f1a-b2dc-00addfbb5c93)
