### PR TITLE
Always display users deposited vaults

### DIFF
--- a/src/hooks/managedVaults/useDepositedManagedVaultsFallback.ts
+++ b/src/hooks/managedVaults/useDepositedManagedVaultsFallback.ts
@@ -1,0 +1,69 @@
+import { getManagedVaultDetails } from 'api/cosmwasm-client'
+import useChainConfig from 'hooks/chain/useChainConfig'
+import useStore from 'store'
+import useSWR from 'swr'
+import useWalletBalances from 'hooks/wallet/useWalletBalances'
+
+export function useDepositedManagedVaultsFallback() {
+  const chainConfig = useChainConfig()
+  const address = useStore((s) => s.address)
+  const { data: walletBalances } = useWalletBalances(address)
+  const hasBalances = walletBalances && walletBalances.length > 0
+
+  const { data: userVaults, isLoading } = useSWR(
+    address && hasBalances ? `chains/${chainConfig.id}/managedVaults/fallback/${address}` : null,
+    async () => {
+      if (!address || !walletBalances) return []
+
+      const vaultTokens = walletBalances
+        .filter(
+          (balance) => balance.denom.startsWith('factory/') && balance.denom.includes('/vault_'),
+        )
+        .map((balance) => {
+          const parts = balance.denom.split('/')
+          return parts[1]
+        })
+
+      console.log('vaultTokens', vaultTokens)
+      if (!vaultTokens.length) return []
+
+      const vaults = await Promise.all(
+        vaultTokens.map(async (vaultAddress) => {
+          try {
+            const details = await getManagedVaultDetails(chainConfig, vaultAddress)
+            return {
+              vault_address: vaultAddress,
+              account_id: details.vault_account_id,
+              title: details.title,
+              subtitle: details.subtitle || '',
+              description: details.description,
+              fee_rate: details.performance_fee_config.fee_rate,
+              fee: '0',
+              tvl: '0',
+              apr: '0',
+              base_tokens_denom: details.base_token,
+              base_tokens_amount: details.total_base_tokens,
+              vault_tokens_denom: details.vault_token,
+              vault_tokens_amount: details.total_vault_tokens,
+              isOwner: false,
+            } as ManagedVaultWithDetails
+          } catch (error) {
+            console.error(`Error fetching details for vault ${vaultAddress}:`, error)
+            return null
+          }
+        }),
+      )
+
+      return vaults.filter(Boolean) as ManagedVaultWithDetails[]
+    },
+    {
+      refreshInterval: 60_000,
+      suspense: false,
+    },
+  )
+
+  return {
+    data: userVaults ?? [],
+    isLoading,
+  }
+}

--- a/src/hooks/managedVaults/useDepositedManagedVaultsFallback.ts
+++ b/src/hooks/managedVaults/useDepositedManagedVaultsFallback.ts
@@ -24,7 +24,6 @@ export function useDepositedManagedVaultsFallback() {
           return parts[1]
         })
 
-      console.log('vaultTokens', vaultTokens)
       if (!vaultTokens.length) return []
 
       const vaults = await Promise.all(

--- a/src/hooks/managedVaults/useManagedVaults.ts
+++ b/src/hooks/managedVaults/useManagedVaults.ts
@@ -43,7 +43,7 @@ export default function useManagedVaults() {
         return vaultsWithDetails
       } catch (error) {
         console.error('Error fetching vaults:', error)
-        throw error
+        return []
       }
     },
     {

--- a/src/hooks/managedVaults/useManagedVaults.ts
+++ b/src/hooks/managedVaults/useManagedVaults.ts
@@ -1,22 +1,23 @@
 import { getManagedVaultDetails, getManagedVaultOwnerAddress } from 'api/cosmwasm-client'
 import getManagedVaults from 'api/managedVaults/getManagedVaults'
 import { useManagedVaultDeposits } from 'hooks/managedVaults/useManagedVaultDeposits'
+import { useDepositedManagedVaultsFallback } from 'hooks/managedVaults/useDepositedManagedVaultsFallback'
 import useChainConfig from 'hooks/chain/useChainConfig'
 import useStore from 'store'
 import useSWR from 'swr'
 import { useMemo } from 'react'
 
-const FALLBACK_RESULT = {
-  ownedVaults: [],
-  depositedVaults: [],
-  availableVaults: [],
-}
-
 export default function useManagedVaults() {
   const chainConfig = useChainConfig()
   const address = useStore((s) => s.address)
+  const { data: fallbackUserVaults, isLoading: isFallbackLoading } =
+    useDepositedManagedVaultsFallback()
 
-  const { data: vaultsResponse, isLoading } = useSWR(
+  const {
+    data: vaultsResponse,
+    isLoading,
+    error,
+  } = useSWR(
     `chains/${chainConfig.id}/managedVaults`,
     async () => {
       try {
@@ -42,7 +43,7 @@ export default function useManagedVaults() {
         return vaultsWithDetails
       } catch (error) {
         console.error('Error fetching vaults:', error)
-        return []
+        throw error
       }
     },
     {
@@ -51,9 +52,16 @@ export default function useManagedVaults() {
       suspense: false,
     },
   )
+
   const vaultDeposits = useManagedVaultDeposits(address, vaultsResponse ?? [])
   const result = useMemo(() => {
-    if (!vaultsResponse) return FALLBACK_RESULT
+    if (error || !vaultsResponse || vaultsResponse.length === 0) {
+      return {
+        ownedVaults: [],
+        depositedVaults: fallbackUserVaults || [],
+        availableVaults: [],
+      }
+    }
 
     return {
       ownedVaults: address ? vaultsResponse.filter((vault) => vault.isOwner) : [],
@@ -68,10 +76,10 @@ export default function useManagedVaults() {
           )
         : vaultsResponse,
     }
-  }, [vaultsResponse, vaultDeposits, address])
+  }, [vaultsResponse, vaultDeposits, address, error, fallbackUserVaults])
 
   return {
     data: result,
-    isLoading,
+    isLoading: isLoading || isFallbackLoading,
   }
 }


### PR DESCRIPTION
This PR includes a 'fallback' deposited vaults when BE api is not working, so users can always see their deposits