### PR TITLE
TWAP price fetching

### DIFF
--- a/src/api/prices/getOraclePrices.ts
+++ b/src/api/prices/getOraclePrices.ts
@@ -64,7 +64,7 @@ export default async function getOraclePrices(
         }, [])
       }
 
-      // Handle share assets individually to prevent
+      // Handle share assets individually to prevent twap errors breaking the app
       if (shareAssets.length > 0) {
         const shareResults = await Promise.all(
           shareAssets.map(async (asset) => {

--- a/src/api/prices/getOraclePrices.ts
+++ b/src/api/prices/getOraclePrices.ts
@@ -76,7 +76,7 @@ export default async function getOraclePrices(
             }
           }),
         )
-        individualPriceResults = shareResults.filter((result) => result !== null) as PriceResponse[]
+        individualPriceResults = shareResults as PriceResponse[]
       }
 
       // Combine all price results

--- a/src/api/prices/getOraclePrices.ts
+++ b/src/api/prices/getOraclePrices.ts
@@ -33,26 +33,54 @@ export default async function getOraclePrices(
       priceResults = await iterateContractQuery(osmosisOracleQueryClient.prices)
     } else {
       const neutronOracleQueryClient = await getOracleQueryClientNeutron(chainConfig)
-      const denoms = assets.map((asset) => asset.denom)
 
-      const denomChunks = chunkArray(denoms, 3)
+      // Filter assets: separate those with 'share' in denom from others
+      const shareAssets = assets.filter((asset) => asset.denom.includes('share'))
+      const nonShareAssets = assets.filter((asset) => !asset.denom.includes('share'))
 
-      const chunkResults = await Promise.all(
-        denomChunks.map(async (chunk) => {
-          return await neutronOracleQueryClient.pricesByDenoms({ denoms: chunk, kind: 'default' })
-        }),
-      )
+      let batchPriceResults: PriceResponse[] = []
+      let individualPriceResults: PriceResponse[] = []
 
-      priceResults = chunkResults.reduce((acc: PriceResponse[], result) => {
-        if (result && typeof result === 'object') {
-          const priceEntries = Object.entries(result).map(([denom, price]) => ({
-            denom,
-            price: String(price),
-          })) as PriceResponse[]
-          return [...acc, ...priceEntries]
-        }
-        return acc
-      }, [])
+      // Handle non-share assets with batching
+      if (nonShareAssets.length > 0) {
+        const denoms = nonShareAssets.map((asset) => asset.denom)
+        const denomChunks = chunkArray(denoms, 3)
+
+        const chunkResults = await Promise.all(
+          denomChunks.map(async (chunk) => {
+            return await neutronOracleQueryClient.pricesByDenoms({ denoms: chunk, kind: 'default' })
+          }),
+        )
+
+        batchPriceResults = chunkResults.reduce((acc: PriceResponse[], result) => {
+          if (result && typeof result === 'object') {
+            const priceEntries = Object.entries(result).map(([denom, price]) => ({
+              denom,
+              price: String(price),
+            })) as PriceResponse[]
+            return [...acc, ...priceEntries]
+          }
+          return acc
+        }, [])
+      }
+
+      // Handle share assets individually to prevent
+      if (shareAssets.length > 0) {
+        const shareResults = await Promise.all(
+          shareAssets.map(async (asset) => {
+            try {
+              return await neutronOracleQueryClient.price({ denom: asset.denom })
+            } catch (error) {
+              console.warn(`Failed to fetch price for share asset ${asset.denom}:`, error)
+              return { denom: asset.denom, price: '0' } as PriceResponse
+            }
+          }),
+        )
+        individualPriceResults = shareResults.filter((result) => result !== null) as PriceResponse[]
+      }
+
+      // Combine all price results
+      priceResults = [...batchPriceResults, ...individualPriceResults]
     }
 
     return assets.map((asset) => {

--- a/src/api/prices/getOraclePrices.ts
+++ b/src/api/prices/getOraclePrices.ts
@@ -35,8 +35,8 @@ export default async function getOraclePrices(
       const neutronOracleQueryClient = await getOracleQueryClientNeutron(chainConfig)
 
       // Filter assets: separate those with 'share' in denom from others
-      const shareAssets = assets.filter((asset) => asset.denom.includes('share'))
-      const nonShareAssets = assets.filter((asset) => !asset.denom.includes('share'))
+      const shareAssets = assets.filter((asset) => asset.denom.endsWith('share'))
+      const nonShareAssets = assets.filter((asset) => !asset.denom.endsWith('share'))
 
       let batchPriceResults: PriceResponse[] = []
       let individualPriceResults: PriceResponse[] = []


### PR DESCRIPTION
This PR introduces logic that separates assets with a `share` suffix in their denom from other assets before fetching prices from the oracle. These prices are TWAP prices and tend to break since the introduction of duality. TO prevent the UI from being unusable, they are now fetched individually.