### PR TITLE
Withdrawal modal fix

### DIFF
--- a/src/components/Modals/FundWithdraw/WithdrawFromAccount.tsx
+++ b/src/components/Modals/FundWithdraw/WithdrawFromAccount.tsx
@@ -25,17 +25,22 @@ interface Props {
 export default function WithdrawFromAccount(props: Props) {
   const { account } = props
   const { data: assets } = useAssets()
-  const tradeEnabledAssets = assets.filter((asset) => asset.isTradeEnabled)
-  const sortedBalances = mergeBNCoinArrays(account.deposits, account.lends)
-    .filter((coin) => tradeEnabledAssets.some((asset) => asset.denom === coin.denom))
-    .sort((a, b) => {
-      const valueA = getCoinValue(a, tradeEnabledAssets)?.toNumber?.() ?? 0
-      const valueB = getCoinValue(b, tradeEnabledAssets)?.toNumber?.() ?? 0
-      return valueB - valueA
-    })
-
-  const defaultAsset =
-    tradeEnabledAssets.find(byDenom(sortedBalances[0]?.denom)) ?? tradeEnabledAssets[0]
+  const tradeEnabledAssets = useMemo(() => assets.filter((asset) => asset.isTradeEnabled), [assets])
+  const sortedBalances = useMemo(
+    () =>
+      mergeBNCoinArrays(account.deposits, account.lends)
+        .filter((coin) => tradeEnabledAssets.some((asset) => asset.denom === coin.denom))
+        .sort((a, b) => {
+          const valueA = getCoinValue(a, tradeEnabledAssets)?.toNumber?.() ?? 0
+          const valueB = getCoinValue(b, tradeEnabledAssets)?.toNumber?.() ?? 0
+          return valueB - valueA
+        }),
+    [account.deposits, account.lends, tradeEnabledAssets],
+  )
+  const defaultAsset = useMemo(
+    () => tradeEnabledAssets.find(byDenom(sortedBalances[0]?.denom)) ?? tradeEnabledAssets[0],
+    [tradeEnabledAssets, sortedBalances],
+  )
 
   const withdraw = useStore((s) => s.withdraw)
   const [withdrawWithBorrowing, setWithdrawWithBorrowing] = useToggle()

--- a/src/components/common/Select/Option.tsx
+++ b/src/components/common/Select/Option.tsx
@@ -61,38 +61,42 @@ export default function Option(props: Props) {
       <div
         data-testid='option-component'
         className={classNames(
-          'grid grid-flow-row grid-cols-5 grid-rows-2 py-3.5 pr-4',
+          'flex gap-4 justify-between items-center py-2 px-4',
           'border-b border-b-white/20 last:border-none',
           'hover:cursor-pointer hover:bg-white/20',
           !props.isSelected ? 'bg-white/10' : 'pointer-events-none',
         )}
         onClick={() => handleOnClick(asset.denom)}
       >
-        <div className='flex items-center justify-center h-full row-span-2'>
+        <div className='flex items-center justify-center gap-4'>
           <AssetImage asset={asset} className='w-8 h-8' />
+          <div className='flex flex-col gap-1'>
+            <Text size='sm'>{asset.symbol}</Text>
+            <AssetRate
+              rate={marketAsset?.apy.borrow ?? 0}
+              isEnabled={marketAsset?.borrowEnabled ?? false}
+              className='text-sm text-white/50'
+              type='apy'
+              orientation='rtl'
+              suffix
+              hasCampaignApy={asset.campaigns.find((c) => c.type === 'apy') !== undefined}
+            />
+          </div>
         </div>
-        <Text className='col-span-2 pb-1'>{asset.symbol}</Text>
-        <Text size='sm' className='col-span-2 pb-1 font-bold text-right'>
-          {formatValue(balance.toString(), {
-            decimals: asset.decimals,
-            maxDecimals: 4,
-            minDecimals: 0,
-            rounded: true,
-          })}
-        </Text>
-        <AssetRate
-          rate={marketAsset?.apy.borrow ?? 0}
-          isEnabled={marketAsset?.borrowEnabled ?? false}
-          className='col-span-2 text-white/50'
-          type='apy'
-          orientation='rtl'
-          suffix
-          hasCampaignApy={asset.campaigns.find((c) => c.type === 'apy') !== undefined}
-        />
-        <DisplayCurrency
-          className='col-span-2 text-sm text-right text-white/50'
-          coin={BNCoin.fromDenomAndBigNumber(asset.denom, balance)}
-        />
+        <div className='flex flex-col gap-2 items-end'>
+          <Text size='sm' className='font-bold'>
+            {formatValue(balance.toString(), {
+              decimals: asset.decimals,
+              maxDecimals: 4,
+              minDecimals: 0,
+              rounded: true,
+            })}
+          </Text>
+          <DisplayCurrency
+            className='text-sm text-white/50'
+            coin={BNCoin.fromDenomAndBigNumber(asset.denom, balance)}
+          />
+        </div>
       </div>
     )
   }

--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -86,7 +86,7 @@ export default function Select(props: Props) {
       setSortedOptions(sorted)
       setIsAssetsLoading(false)
     }, remainingTime)
-  }, [props.options, selected, handleChange, assets])
+  }, [getOptionValue, handleChange, props.options, selected])
 
   const handleToggleDropdown = useCallback(() => {
     if (!showDropdown) {

--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -160,7 +160,7 @@ export default function Select(props: Props) {
         >
           <div className='relative w-full overflow-hidden rounded-sm isolate'>
             {props.title && (
-              <Text size='lg' className='block p-4 font-bold bg-white/25'>
+              <Text size='sm' className='block p-4 font-bold bg-white/25'>
                 {props.title}
               </Text>
             )}


### PR DESCRIPTION
- filtering out assets that are `tradeEnabled: false` which was breaking the selection
- sorting assets by their value
- preselecting asset with the highest value
- updated styling a bit 


<img width="581" alt="Screenshot 2025-06-18 at 3 07 13 PM" src="https://github.com/user-attachments/assets/2ab24acf-4e92-4441-86f9-a16f61299d22" />
