### PR TITLE
Vault withdrawal

### DIFF
--- a/src/components/managedVaults/vaultDetails/common/Overlays/VaultAction.tsx
+++ b/src/components/managedVaults/vaultDetails/common/Overlays/VaultAction.tsx
@@ -42,7 +42,7 @@ export default function VaultAction(props: Props) {
   const { data: account } = useAccount(vaultDetails.vault_account_id || undefined)
   const { data: userPosition } = useManagedVaultUserPosition(vaultAddress, address)
   const { data: userUnlocks = [] } = useUserUnlocks(vaultAddress)
-  const { data: sharesToUnlock } = useManagedVaultConvertToShares(vaultAddress, amount.toString())
+  const { data: sharesToUnlock } = useManagedVaultConvertToShares(vaultAddress, amount.toFixed(0))
   const { computeMaxWithdrawAmount, computeMaxBorrowAmount } = useHealthComputer(account)
   const depositInManagedVault = useStore((s) => s.depositInManagedVault)
   const unlockFromManagedVault = useStore((s) => s.unlockFromManagedVault)
@@ -113,7 +113,7 @@ export default function VaultAction(props: Props) {
       } else {
         await depositInManagedVault({
           vaultAddress,
-          amount: amount.toString(),
+          amount: amount.toFixed(0),
           baseTokenDenom: vaultDetails.base_tokens_denom,
         })
       }


### PR DESCRIPTION
This PR updates logic for withdrawals from vaults
- Maximum withdrawal is based on actual vault shares owned
- we calculate available shares first, then convert to price for display
- All calculations are protected to never go below zero
