### PR TITLE
fix: removed unrelated swapping messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine as builder
 WORKDIR /app
 
-COPY package.json yarn.lock ./
+COPY package.json ./
 RUN yarn install
 COPY . .
 RUN apk --update add patch


### PR DESCRIPTION
This PR fixes including `CancelLimitOrder` events from the duality swap toasts