### PR TITLE
Vault fetch fix

### DIFF
--- a/src/components/managedVaults/table/AvailableCommunityVaults.tsx
+++ b/src/components/managedVaults/table/AvailableCommunityVaults.tsx
@@ -49,10 +49,7 @@ export default function AvailableCommunityVaults() {
     return tabs
   }, [data.depositedVaults, data.ownedVaults, isLoading])
 
-  const hasNoVaults =
-    !data.ownedVaults.length && !data.depositedVaults.length && !data.availableVaults.length
-
-  if (isLoading || hasNoVaults) {
+  if (isLoading) {
     return (
       <div className='flex justify-center w-full mt-10'>
         <CircularProgress size={50} />

--- a/src/hooks/managedVaults/useManagedVaults.ts
+++ b/src/hooks/managedVaults/useManagedVaults.ts
@@ -4,8 +4,8 @@ import { useManagedVaultDeposits } from 'hooks/managedVaults/useManagedVaultDepo
 import { useDepositedManagedVaultsFallback } from 'hooks/managedVaults/useDepositedManagedVaultsFallback'
 import useChainConfig from 'hooks/chain/useChainConfig'
 import useStore from 'store'
-import useSWR from 'swr'
-import { useMemo } from 'react'
+import useSWR, { mutate } from 'swr'
+import { useEffect, useMemo, useState } from 'react'
 import BN from 'bignumber.js'
 
 export default function useManagedVaults() {
@@ -121,30 +121,56 @@ export default function useManagedVaults() {
     },
     {
       revalidateOnFocus: false,
-      refreshInterval: 60_000,
       suspense: false,
+      refreshInterval: (latestData) => {
+        if (Array.isArray(latestData) && latestData.length === 0) {
+          return 2000 // 2 seconds if empty
+        }
+        return 120000 // else 120 seconds
+      },
+      onSuccess: (data) => {
+        if (Array.isArray(data) && data.length === 0) {
+          setTimeout(() => mutate(`chains/${chainConfig.id}/managedVaults`), 2000)
+        }
+      },
     },
   )
 
-  const vaultDeposits = useManagedVaultDeposits(address, vaultsResponse ?? [])
+  // Add local state for last valid (non-empty) vaults
+  const [lastValidVaults, setLastValidVaults] = useState<ManagedVaultWithDetails[]>([])
+  useEffect(() => {
+    if (
+      vaultsResponse &&
+      vaultsResponse.length > 0 &&
+      vaultsResponse.some((vault) => BN(vault.base_tokens_amount).isGreaterThan(0))
+    ) {
+      setLastValidVaults(vaultsResponse)
+    }
+  }, [vaultsResponse])
+
+  // Use last valid data if current response is empty or returns no funded vaults
+  const dataToUse =
+    vaultsResponse &&
+    vaultsResponse.length > 0 &&
+    vaultsResponse.some((vault) => BN(vault.base_tokens_amount).isGreaterThan(0))
+      ? vaultsResponse
+      : lastValidVaults
+
+  const vaultDeposits = useManagedVaultDeposits(address, dataToUse ?? [])
   const result = useMemo(() => {
-    if (error || !vaultsResponse || vaultsResponse.length === 0) {
+    if (error || !dataToUse || dataToUse.length === 0) {
       return {
         ownedVaults: fallbackUserVaults.filter((vault) => vault.isOwner) || [],
         depositedVaults: fallbackUserVaults.filter((vault) => !vault.isOwner) || [],
         availableVaults: [],
       }
     }
-
     // Filter out unfunded vaults (those with zero total_base_tokens) for available vaults table
-    const fundedVaults = vaultsResponse.filter((vault) =>
-      BN(vault.base_tokens_amount).isGreaterThan(0),
-    )
-
+    const fundedVaults = dataToUse.filter((vault) => BN(vault.base_tokens_amount).isGreaterThan(0))
     return {
-      ownedVaults: address ? vaultsResponse.filter((vault) => vault.isOwner) : [],
+      ownedVaults: address ? dataToUse.filter((vault) => vault.isOwner) : [],
       depositedVaults: address
-        ? vaultsResponse.filter(
+        ? dataToUse.filter(
             (vault) => !vault.isOwner && vaultDeposits.get(vault.vault_tokens_denom) === true,
           )
         : [],
@@ -154,10 +180,10 @@ export default function useManagedVaults() {
           )
         : fundedVaults,
     }
-  }, [vaultsResponse, vaultDeposits, address, error, fallbackUserVaults])
+  }, [dataToUse, vaultDeposits, address, error, fallbackUserVaults])
 
   return {
     data: result,
-    isLoading: isLoading || isFallbackLoading,
+    isLoading: (isLoading || isFallbackLoading) && dataToUse.length === 0,
   }
 }

--- a/src/hooks/managedVaults/useManagedVaults.ts
+++ b/src/hooks/managedVaults/useManagedVaults.ts
@@ -132,15 +132,6 @@ export default function useManagedVaults() {
         }
         return 120000 // else 120 seconds
       },
-      onSuccess: (data) => {
-        if (
-          Array.isArray(data) &&
-          (data.length === 0 ||
-            !data.some((vault) => BN(vault.base_tokens_amount).isGreaterThan(0)))
-        ) {
-          setTimeout(() => mutate(`chains/${chainConfig.id}/managedVaults`), 2000)
-        }
-      },
     },
   )
 

--- a/src/hooks/managedVaults/useManagedVaults.ts
+++ b/src/hooks/managedVaults/useManagedVaults.ts
@@ -123,13 +123,21 @@ export default function useManagedVaults() {
       revalidateOnFocus: false,
       suspense: false,
       refreshInterval: (latestData) => {
-        if (Array.isArray(latestData) && latestData.length === 0) {
+        if (
+          Array.isArray(latestData) &&
+          (latestData.length === 0 ||
+            !latestData.some((vault) => BN(vault.base_tokens_amount).isGreaterThan(0)))
+        ) {
           return 2000 // 2 seconds if empty
         }
         return 120000 // else 120 seconds
       },
       onSuccess: (data) => {
-        if (Array.isArray(data) && data.length === 0) {
+        if (
+          Array.isArray(data) &&
+          (data.length === 0 ||
+            !data.some((vault) => BN(vault.base_tokens_amount).isGreaterThan(0)))
+        ) {
           setTimeout(() => mutate(`chains/${chainConfig.id}/managedVaults`), 2000)
         }
       },


### PR DESCRIPTION
This PR fixes extensive loading when no vaults are available 

- Refetch vaults every 2s if the API returns no funded vaults (TVL < 0), or error -  otherwise every 2 minutes.
- Store and display the last valid set of vaults in a state if the API returns empty or unfunded vaults.
- Show the loading spinner only when there is truly no data to display.
- Removed unnecessary “no vaults” checks in the UI (UI always shows the last valid data or a loading state if it's refetching)