### PR TITLE
Add staking tiers to vaults

### DIFF
--- a/src/components/managedVaults/table/column/ActiveBenefits.tsx
+++ b/src/components/managedVaults/table/column/ActiveBenefits.tsx
@@ -1,0 +1,29 @@
+import Loading from 'components/common/Loading'
+import TierLabel from 'components/staking/TierLabel'
+import { useStakedMars } from 'hooks/staking/useNeutronStakingData'
+import { useMemo } from 'react'
+
+interface Props {
+  vault: ManagedVaultWithDetails
+}
+
+export const ACTIVE_BENEFITS_META = {
+  id: 'activeBenefits',
+  header: 'Active Benefits',
+  accessorKey: 'activeBenefits',
+  meta: {
+    className: 'w-36',
+  },
+}
+
+export default function ActiveBenefits({ vault }: Props) {
+  const { data: stakedMarsData } = useStakedMars(vault.ownerAddress)
+
+  const stakedAmount = useMemo(
+    () => (!vault.ownerAddress ? 0 : stakedMarsData?.stakedAmount?.toNumber() || 0),
+    [vault.ownerAddress, stakedMarsData],
+  )
+  if (!vault.ownerAddress) return <Loading className='w-16 h-6 justify-self-end' />
+
+  return <TierLabel amount={stakedAmount} withTooltip wrapperClassName='justify-end' />
+}

--- a/src/components/managedVaults/table/useCommunityVaultsColumns.tsx
+++ b/src/components/managedVaults/table/useCommunityVaultsColumns.tsx
@@ -1,5 +1,8 @@
 import { ColumnDef, Row } from '@tanstack/react-table'
 import Button from 'components/common/Button'
+import ActiveBenefits, {
+  ACTIVE_BENEFITS_META,
+} from 'components/managedVaults/table/column/ActiveBenefits'
 import Apy, { APY_META } from 'components/managedVaults/table/column/Apy'
 import Details, { DETAILS_META } from 'components/managedVaults/table/column/Details'
 import Fee, { FEE_META } from 'components/managedVaults/table/column/Fee'
@@ -57,6 +60,12 @@ export default function useCommunityVaultsColumns(props: Props) {
             },
           ]
         : []),
+      {
+        ...ACTIVE_BENEFITS_META,
+        cell: ({ row }: { row: Row<ManagedVaultWithDetails> }) => (
+          <ActiveBenefits vault={row.original} />
+        ),
+      },
       {
         ...TVL_META,
         cell: ({ row }: { row: Row<ManagedVaultWithDetails> }) => (

--- a/src/components/managedVaults/vaultDetails/profileVaultCard/InfoRow.tsx
+++ b/src/components/managedVaults/vaultDetails/profileVaultCard/InfoRow.tsx
@@ -9,7 +9,7 @@ export default function InfoRow(props: Props) {
   const { label, children } = props
 
   return (
-    <div className='flex justify-between'>
+    <div className='flex justify-between items-center'>
       <Text size='sm' className='text-white/60'>
         {label}
       </Text>

--- a/src/components/managedVaults/vaultDetails/profileVaultCard/ProfileVaultCard.tsx
+++ b/src/components/managedVaults/vaultDetails/profileVaultCard/ProfileVaultCard.tsx
@@ -15,11 +15,13 @@ import { TextLink } from 'components/common/TextLink'
 import { Tooltip } from 'components/common/Tooltip'
 import FeeTag from 'components/managedVaults/vaultDetails/profileVaultCard/FeeTag'
 import InfoRow from 'components/managedVaults/vaultDetails/profileVaultCard/InfoRow'
+import TierLabel from 'components/staking/TierLabel'
 import useChainConfig from 'hooks/chain/useChainConfig'
-import useManagedVaultOwnerInfo from 'hooks/managedVaults/useManagedVaultOwnerInfo'
-import useManagedVaultPnl from 'hooks/managedVaults/useManagedVaultPnl'
 import useManagedVaultAge from 'hooks/managedVaults/useManagedVaultAge'
+import useManagedVaultOwnerInfo from 'hooks/managedVaults/useManagedVaultOwnerInfo'
 import useManagedVaultOwnerPosition from 'hooks/managedVaults/useManagedVaultOwnerPosition'
+import useManagedVaultPnl from 'hooks/managedVaults/useManagedVaultPnl'
+import { useStakedMars } from 'hooks/staking/useNeutronStakingData'
 import moment from 'moment'
 import Image from 'next/image'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -50,6 +52,7 @@ export default function ProfileVaultCard(props: Props) {
     details.ownerAddress,
   )
   const ownerSharesPercentage = calculateOwnerVaultShare(details.vault_tokens_amount)
+  const { data: stakedMarsData } = useStakedMars(details.ownerAddress)
 
   const handleManageVault = () => {
     navigate(
@@ -203,6 +206,31 @@ export default function ProfileVaultCard(props: Props) {
                 <ExternalLink className='ml-2 inline w-4' />
               </TextLink>
             </div>
+          </InfoRow>
+          <InfoRow label='Staked Mars'>
+            {!stakedMarsData ? (
+              <Loading className='h-4 w-20' />
+            ) : (
+              <FormattedNumber
+                amount={stakedMarsData.stakedAmount.toNumber()}
+                options={{
+                  suffix: ' MARS',
+                  abbreviated: true,
+                }}
+                className='text-sm'
+              />
+            )}
+          </InfoRow>
+          <InfoRow label='Active Staking Benefits'>
+            {!stakedMarsData ? (
+              <Loading className='h-4 w-20' />
+            ) : (
+              <TierLabel
+                amount={stakedMarsData.stakedAmount.toNumber()}
+                withTooltip
+                className='text-xs'
+              />
+            )}
           </InfoRow>
           {vaultOwnerInfo.socials.length > 0 && (
             <InfoRow label='Contact'>

--- a/src/components/staking/TierLabel.tsx
+++ b/src/components/staking/TierLabel.tsx
@@ -8,10 +8,12 @@ export default function TierLabel({
   amount,
   className,
   withTooltip = false,
+  wrapperClassName,
 }: {
   amount: number
   withTooltip?: boolean
   className?: string
+  wrapperClassName?: string
 }) {
   const { calculateTier } = useTierSystem()
   const tier = calculateTier(amount)
@@ -30,7 +32,7 @@ export default function TierLabel({
   }
 
   return (
-    <div className='flex items-center gap-1'>
+    <div className={classNames('flex items-center gap-1', wrapperClassName)}>
       {tierLabel}
       <Tooltip
         type='info'

--- a/src/hooks/managedVaults/useManagedVaults.ts
+++ b/src/hooks/managedVaults/useManagedVaults.ts
@@ -1,12 +1,12 @@
 import { getManagedVaultDetails, getManagedVaultOwnerAddress } from 'api/cosmwasm-client'
 import getManagedVaults from 'api/managedVaults/getManagedVaults'
-import { useManagedVaultDeposits } from 'hooks/managedVaults/useManagedVaultDeposits'
-import { useDepositedManagedVaultsFallback } from 'hooks/managedVaults/useDepositedManagedVaultsFallback'
-import useChainConfig from 'hooks/chain/useChainConfig'
-import useStore from 'store'
-import useSWR, { mutate } from 'swr'
-import { useEffect, useMemo, useState } from 'react'
 import BN from 'bignumber.js'
+import useChainConfig from 'hooks/chain/useChainConfig'
+import { useDepositedManagedVaultsFallback } from 'hooks/managedVaults/useDepositedManagedVaultsFallback'
+import { useManagedVaultDeposits } from 'hooks/managedVaults/useManagedVaultDeposits'
+import { useEffect, useMemo, useState } from 'react'
+import useStore from 'store'
+import useSWR from 'swr'
 
 export default function useManagedVaults() {
   const chainConfig = useChainConfig()
@@ -43,10 +43,7 @@ export default function useManagedVaults() {
             try {
               const details = await getManagedVaultDetails(chainConfig, vault.vault_address)
               if (!details) return null
-              let owner = null
-              if (address) {
-                owner = await getManagedVaultOwnerAddress(chainConfig, vault.vault_address)
-              }
+              const owner = await getManagedVaultOwnerAddress(chainConfig, vault.vault_address)
 
               return {
                 ...vault,
@@ -59,7 +56,8 @@ export default function useManagedVaults() {
                 base_tokens_amount: details.total_base_tokens,
                 vault_tokens_denom: details.vault_token,
                 vault_tokens_amount: details.total_vault_tokens,
-                isOwner: owner === address,
+                ownerAddress: owner,
+                isOwner: address ? owner === address : false,
                 isPending: pendingVault?.address === vault.vault_address,
               } as ManagedVaultWithDetails
             } catch (error) {


### PR DESCRIPTION
This PR adds staking information to the vaults overview. This will help users identify vaults with very low trading fees.

![IMAGE 2025-09-24 19:06:47](https://github.com/user-attachments/assets/cab0d50f-3348-4c0c-b066-2781c9121b0a)
![IMAGE 2025-09-24 19:06:49](https://github.com/user-attachments/assets/a8c6df76-f1eb-44b0-a6cd-f170c4f0eefb)
